### PR TITLE
NPG-50 공통 ResponseDto 추가 (예제코드 포함)

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ExampleResponseDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ExampleResponseDto.java
@@ -1,0 +1,25 @@
+package com.mars.NangPaGo.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 이 Dto 클래스는 단순한 예제코드를 위해 작성한 것으로, 조만간 삭제할 예정입니다.
+// TODO: 이 파일 제거 예정
+@Getter
+public class ExampleResponseDto {
+    private final String name;
+    private final String email;
+
+    @Builder
+    private ExampleResponseDto(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    public static ExampleResponseDto of(String name, String email) {
+        return ExampleResponseDto.builder()
+            .name(name)
+            .email(email)
+            .build();
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ResponseDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ResponseDto.java
@@ -1,0 +1,28 @@
+package com.mars.NangPaGo.common.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseDto<T> {
+    private final T data;
+    private final String message;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ResponseDto(T data, String message) {
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> ResponseDto<T> of(T data, String message) {
+        return ResponseDto.<T>builder()
+            .data(data)
+            .message(message)
+            .build();
+    }
+
+    public static <T> ResponseDto<T> of(T data) {
+        return ResponseDto.of(data, "");
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -46,7 +46,14 @@ public class SecurityConfig {
             );
         http
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/oauth2/**", "/auth/reissue", "/auth/status").permitAll()
+                .requestMatchers(
+                    "/",
+                    "/login",
+                    "/oauth2/**",
+                    "/auth/reissue",
+                    "/auth/status",
+                    "/common/example"  // TODO: 제거 예정
+                ).permitAll()
                 .anyRequest().authenticated());
         http.addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenRepository), LogoutFilter.class);
         http

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/controller/HomeController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/controller/HomeController.java
@@ -1,5 +1,7 @@
 package com.mars.NangPaGo.controller;
 
+import com.mars.NangPaGo.common.dto.ExampleResponseDto;
+import com.mars.NangPaGo.common.dto.ResponseDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,5 +11,13 @@ public class HomeController {
     @GetMapping("/nangpago")
     public String nangPaGo() {
         return "냉파고의 시작";
+    }
+
+    // TODO: 이 엔드포인트 삭제 (단순 예제를 위해 만듦)
+    @GetMapping("/common/example")
+    public ResponseDto<ExampleResponseDto> exampleResponseDto() {
+        ExampleResponseDto exampleResponseDto = ExampleResponseDto.of("공통 DTO", "common@example.com");
+
+        return ResponseDto.of(exampleResponseDto, "Message는 필요할때만 입력해도 됨");
     }
 }


### PR DESCRIPTION
## 📝작업 내용

- 응답 메시지 공통화를 위한 ResponseDto 추가
- 사용 예제 포함
  - 예제는 이 PR 머지 직전에 삭제 예정

### 스크린샷 (선택)

- Controller 코드를 아래처럼 작성하면
<img width="878" alt="image" src="https://github.com/user-attachments/assets/1f630e3b-3a25-418e-9129-de35c791f0cc" />

- 정상(200) 코드와 함께 응답 메시지가 공통 템플릿 안에 들어가게 됩니다
<img width="622" alt="image" src="https://github.com/user-attachments/assets/c4532ba2-f343-4722-9c6b-2caafcff4169" />


## 리뷰 요청사항

