### PR TITLE
[NPG-54] 공통 `ResponseDto`, `GlobalExceptionHandler` 추가

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ExampleResponseDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ExampleResponseDto.java
@@ -1,0 +1,25 @@
+package com.mars.NangPaGo.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 이 Dto 클래스는 단순한 예제코드를 위해 작성한 것으로, 조만간 삭제할 예정입니다.
+// TODO: 이 파일 제거 예정
+@Getter
+public class ExampleResponseDto {
+    private final String name;
+    private final String email;
+
+    @Builder
+    private ExampleResponseDto(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    public static ExampleResponseDto of(String name, String email) {
+        return ExampleResponseDto.builder()
+            .name(name)
+            .email(email)
+            .build();
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ResponseDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/dto/ResponseDto.java
@@ -1,0 +1,28 @@
+package com.mars.NangPaGo.common.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseDto<T> {
+    private final T data;
+    private final String message;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ResponseDto(T data, String message) {
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> ResponseDto<T> of(T data, String message) {
+        return ResponseDto.<T>builder()
+            .data(data)
+            .message(message)
+            .build();
+    }
+
+    public static <T> ResponseDto<T> of(T data) {
+        return ResponseDto.of(data, "");
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/GlobalExceptionHandler.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/GlobalExceptionHandler.java
@@ -1,15 +1,29 @@
 package com.mars.NangPaGo.common.exception;
 
-import org.springframework.http.HttpStatus;
+import com.mars.NangPaGo.common.dto.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+@Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<String> handleIllegalStateException(IllegalStateException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    @ExceptionHandler(NPGException.class)
+    public ResponseEntity<Object> handleNPGException(NPGException exception) {
+        if (exception.isMessageNotEmpty()) {
+            log.warn("[{}] {}", exception.getNpgExceptionType().name(), this);
+        }
+
+        if (exception.isInternalServerError()) {
+            log.error("Internal Server Error, type: {}", exception.getNpgExceptionType(), exception);
+        }
+
+        int httpStatus = exception.getNpgExceptionType().getHttpStatus().value();
+        ResponseDto<String> responseDto = ResponseDto.of("", exception.getMessage());
+
+        return ResponseEntity.status(httpStatus).body(responseDto);
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGException.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGException.java
@@ -1,0 +1,28 @@
+package com.mars.NangPaGo.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NPGException extends RuntimeException {
+    private NPGExceptionType npgExceptionType;
+    private String message;
+
+    public NPGException(NPGExceptionType npgExceptionType) {
+        this.npgExceptionType = npgExceptionType;
+        this.message = npgExceptionType.getDefaultMessage();
+    }
+
+    public NPGException(NPGExceptionType npgExceptionType, String message) {
+        this.npgExceptionType = npgExceptionType;
+        this.message = message;
+    }
+
+    public boolean isMessageNotEmpty() {
+        return this.message != null && !this.message.isEmpty();
+    }
+
+    public boolean isInternalServerError() {
+        return this.npgExceptionType.getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
@@ -1,0 +1,25 @@
+package com.mars.NangPaGo.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NPGExceptionType {
+    // Success
+    OK(HttpStatus.OK, "Success"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String defaultMessage;
+
+    public NPGException of() {
+        return new NPGException(this);
+    }
+
+    public NPGException of(String message) {
+        return new NPGException(this, message);
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
@@ -10,6 +10,14 @@ public enum NPGExceptionType {
     // Success
     OK(HttpStatus.OK, "Success"),
 
+    // BAD_REQUEST(400)
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청"),
+
+    // (404)
+    NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않음"),
+
+    // Internal Server Error(500)
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
     ;
 
     private final HttpStatus httpStatus;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -46,7 +46,14 @@ public class SecurityConfig {
             );
         http
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/oauth2/**", "/auth/reissue", "/auth/status").permitAll()
+                .requestMatchers(
+                    "/",
+                    "/login",
+                    "/oauth2/**",
+                    "/auth/reissue",
+                    "/auth/status",
+                    "/common/example"  // TODO: 제거 예정
+                ).permitAll()
                 .anyRequest().authenticated());
         http.addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenRepository), LogoutFilter.class);
         http

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                     "/oauth2/**",
                     "/auth/reissue",
                     "/auth/status",
-                    "/common/example"  // TODO: 제거 예정
+                    "/common/example/**"  // TODO: 제거 예정
                 ).permitAll()
                 .anyRequest().authenticated());
         http.addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenRepository), LogoutFilter.class);

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/controller/HomeController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/controller/HomeController.java
@@ -1,5 +1,7 @@
 package com.mars.NangPaGo.controller;
 
+import com.mars.NangPaGo.common.dto.ExampleResponseDto;
+import com.mars.NangPaGo.common.dto.ResponseDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,5 +11,13 @@ public class HomeController {
     @GetMapping("/nangpago")
     public String nangPaGo() {
         return "냉파고의 시작";
+    }
+
+    // TODO: 이 엔드포인트 삭제 (단순 예제를 위해 만듦)
+    @GetMapping("/common/example")
+    public ResponseDto<ExampleResponseDto> exampleResponseDto() {
+        ExampleResponseDto exampleResponseDto = ExampleResponseDto.of("공통 DTO", "common@example.com");
+
+        return ResponseDto.of(exampleResponseDto, "Message는 필요할때만 입력해도 됨");
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/controller/HomeController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/controller/HomeController.java
@@ -2,6 +2,7 @@ package com.mars.NangPaGo.controller;
 
 import com.mars.NangPaGo.common.dto.ExampleResponseDto;
 import com.mars.NangPaGo.common.dto.ResponseDto;
+import com.mars.NangPaGo.common.exception.NPGExceptionType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,11 +14,23 @@ public class HomeController {
         return "냉파고의 시작";
     }
 
-    // TODO: 이 엔드포인트 삭제 (단순 예제를 위해 만듦)
-    @GetMapping("/common/example")
-    public ResponseDto<ExampleResponseDto> exampleResponseDto() {
+    // TODO: 엔드포인트 삭제 (단순 예제를 위해 만듦)
+    @GetMapping("/common/example/ok")
+    public ResponseDto<ExampleResponseDto> exampleResponseDtoOk() {
         ExampleResponseDto exampleResponseDto = ExampleResponseDto.of("공통 DTO", "common@example.com");
 
         return ResponseDto.of(exampleResponseDto, "Message는 필요할때만 입력해도 됨");
+    }
+
+    // TODO: 엔드포인트 삭제 (단순 예제를 위해 만듦)
+    @GetMapping("/common/example/exception/400")
+    public ResponseDto<ExampleResponseDto> exampleResponseDtoException400() {
+        throw NPGExceptionType.BAD_REQUEST.of("BAD_REQUEST 예외 발생 예시");
+    }
+
+    // TODO: 엔드포인트 삭제 (단순 예제를 위해 만듦)
+    @GetMapping("/common/example/exception/500")
+    public ResponseDto<ExampleResponseDto> exampleResponseDtoException500() {
+        throw NPGExceptionType.SERVER_ERROR.of("INTERNAL_SERVER_ERROR 예외 발생 예시");
     }
 }


### PR DESCRIPTION
## 📝작업 내용

- 응답 본문에 대한 템플릿화를 위한 공통 ResponseDto 추가
- GlobalExceptinoHandler 기반 예외처리 구조 개선

### 스크린샷 (선택)

- 정상 응답일 때
<img width="621" alt="스크린샷 2024-12-27 오전 12 21 36" src="https://github.com/user-attachments/assets/9d26dd8c-0d0a-4235-ab7d-7b525069a460" />

- `400` 에러 예외 발생 예시
<img width="567" alt="스크린샷 2024-12-27 오전 11 42 31" src="https://github.com/user-attachments/assets/7ecb63ea-46a4-4da9-a92f-d92eba21ef91" />
<img width="991" alt="스크린샷 2024-12-27 오전 11 41 02" src="https://github.com/user-attachments/assets/c634e722-d711-4f4f-82be-7fbde1ca7d1e" />

- `500` 에러 예외 발생 예시
<img width="659" alt="스크린샷 2024-12-27 오전 11 42 22" src="https://github.com/user-attachments/assets/51d9f548-e8ab-4710-b18e-f62a168cecaa" />
<img width="1453" alt="스크린샷 2024-12-27 오전 11 41 33" src="https://github.com/user-attachments/assets/b7a434d5-ddb5-4e88-a81a-115b4ae74d4e" />


## 리뷰 요청사항

