### PR TITLE
[NO-ISSUE] 로그아웃 트랜잭션을 서비스계층으로 따로 분리하여 수정

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.mars.NangPaGo.config;
 import com.mars.NangPaGo.domain.user.auth.CustomLogoutFilter;
 import com.mars.NangPaGo.domain.user.auth.CustomSuccessHandler;
 import com.mars.NangPaGo.domain.user.repository.RefreshTokenRepository;
+import com.mars.NangPaGo.domain.user.service.CustomLogoutService;
 import com.mars.NangPaGo.domain.user.service.CustomOAuth2UserService;
 import com.mars.NangPaGo.domain.user.util.JwtFilter;
 import com.mars.NangPaGo.domain.user.util.JwtUtil;
@@ -26,6 +27,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomLogoutService customLogoutService;
     private final CustomSuccessHandler customSuccessHandler;
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -48,8 +50,9 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/login", "/oauth2/**", "/auth/reissue", "/auth/status").permitAll()
                 .anyRequest().authenticated());
-        http.addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenRepository), LogoutFilter.class);
+        http.addFilterBefore(new CustomLogoutFilter(customLogoutService), LogoutFilter.class);
         http
+
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/auth/CustomSuccessHandler.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/auth/CustomSuccessHandler.java
@@ -48,11 +48,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.sendRedirect("http://localhost:5173/");
     }
 
-
     private void saveRefreshToken(String email, String refreshToken) {
         LocalDateTime expiration = LocalDateTime.now().plusNanos(jwtUtil.getRefreshTokenExpireMillis() * 1_000_000);
         refreshTokenRepository.deleteByRefreshToken(email);
-        refreshTokenRepository.save(new RefreshTokenDto(refreshToken, email, expiration).toEntity());
+        refreshTokenRepository.save(new RefreshTokenDto(email, refreshToken, expiration).toEntity());
     }
 
     private Cookie createCookie(String key, String value, long expireMillis) {

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/CustomLogoutService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/CustomLogoutService.java
@@ -1,0 +1,56 @@
+package com.mars.NangPaGo.domain.user.service;
+
+import com.mars.NangPaGo.domain.user.repository.RefreshTokenRepository;
+import com.mars.NangPaGo.domain.user.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomLogoutService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void handleLogout(String refreshToken, HttpServletResponse response) {
+        validateRefreshToken(refreshToken);
+
+        if (!refreshTokenRepository.existsByRefreshToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
+
+        invalidateCookie(response, "refresh");
+        invalidateCookie(response, "access");
+
+        response.setStatus(HttpStatus.OK.value());
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        try {
+            if (jwtUtil.isExpired(refreshToken)) {
+                throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
+            }
+
+            if (!"refresh".equals(jwtUtil.getCategory(refreshToken))) {
+                throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            }
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
+        }
+    }
+
+    private void invalidateCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+}

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/TokenService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/TokenService.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class TokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    @Transactional
     public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = getRefreshTokenFromRequest(request);
         validateRefreshToken(refreshToken);

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/TokenService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/TokenService.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +19,6 @@ public class TokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    @Transactional
     public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = getRefreshTokenFromRequest(request);
         validateRefreshToken(refreshToken);
@@ -66,7 +64,7 @@ public class TokenService {
     }
 
     private void saveNewRefreshToken(String email, String refreshToken) {
-        refreshTokenRepository.save(new RefreshTokenDto(refreshToken, email,
+        refreshTokenRepository.save(new RefreshTokenDto(email, refreshToken,
             LocalDateTime.now().plusNanos(jwtUtil.getRefreshTokenExpireMillis() * 1_000_000)).toEntity());
     }
 


### PR DESCRIPTION
## 📝작업 내용

> 로그아웃 로직을 필터에서 서비스계층으로 옮겨 수정

### 여기서 얻은 내용
> 필터에서 트랜잭션을 걸면 시큐리티 필터에서 `GenericFilterBean` 얘를 초기화를 못시킴
> JPA의 remove 는 항상 트랜잭션을 필수로 해주어야 함

### 스크린샷 (선택)

## 리뷰 요청사항

