### PR TITLE
[NPG-69] Token 관련 코드를 `jwt` 도메인 하위로 이전

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -2,11 +2,10 @@ package com.mars.NangPaGo.config;
 
 import com.mars.NangPaGo.domain.user.auth.CustomLogoutFilter;
 import com.mars.NangPaGo.domain.user.auth.CustomSuccessHandler;
-import com.mars.NangPaGo.domain.user.repository.RefreshTokenRepository;
 import com.mars.NangPaGo.domain.user.service.CustomLogoutService;
 import com.mars.NangPaGo.domain.user.service.CustomOAuth2UserService;
-import com.mars.NangPaGo.domain.user.util.JwtFilter;
-import com.mars.NangPaGo.domain.user.util.JwtUtil;
+import com.mars.NangPaGo.domain.jwt.util.JwtFilter;
+import com.mars.NangPaGo.domain.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/controller/TokenController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/controller/TokenController.java
@@ -1,6 +1,6 @@
-package com.mars.NangPaGo.domain.user.controller;
+package com.mars.NangPaGo.domain.jwt.controller;
 
-import com.mars.NangPaGo.domain.user.service.TokenService;
+import com.mars.NangPaGo.domain.jwt.service.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/dto/RefreshTokenDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/dto/RefreshTokenDto.java
@@ -1,6 +1,6 @@
-package com.mars.NangPaGo.domain.user.dto;
+package com.mars.NangPaGo.domain.jwt.dto;
 
-import com.mars.NangPaGo.domain.user.entity.RefreshToken;
+import com.mars.NangPaGo.domain.jwt.entity.RefreshToken;
 
 import java.time.LocalDateTime;
 

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/entity/RefreshToken.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/entity/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.mars.NangPaGo.domain.user.entity;
+package com.mars.NangPaGo.domain.jwt.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/repository/RefreshTokenRepository.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/repository/RefreshTokenRepository.java
@@ -1,6 +1,6 @@
-package com.mars.NangPaGo.domain.user.repository;
+package com.mars.NangPaGo.domain.jwt.repository;
 
-import com.mars.NangPaGo.domain.user.entity.RefreshToken;
+import com.mars.NangPaGo.domain.jwt.entity.RefreshToken;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/service/TokenService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/service/TokenService.java
@@ -1,8 +1,8 @@
-package com.mars.NangPaGo.domain.user.service;
+package com.mars.NangPaGo.domain.jwt.service;
 
-import com.mars.NangPaGo.domain.user.dto.RefreshTokenDto;
-import com.mars.NangPaGo.domain.user.repository.RefreshTokenRepository;
-import com.mars.NangPaGo.domain.user.util.JwtUtil;
+import com.mars.NangPaGo.domain.jwt.dto.RefreshTokenDto;
+import com.mars.NangPaGo.domain.jwt.repository.RefreshTokenRepository;
+import com.mars.NangPaGo.domain.jwt.util.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/util/JwtFilter.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/util/JwtFilter.java
@@ -1,4 +1,4 @@
-package com.mars.NangPaGo.domain.user.util;
+package com.mars.NangPaGo.domain.jwt.util;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/util/JwtUtil.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/jwt/util/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.mars.NangPaGo.domain.user.util;
+package com.mars.NangPaGo.domain.jwt.util;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/auth/CustomSuccessHandler.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/auth/CustomSuccessHandler.java
@@ -1,8 +1,8 @@
 package com.mars.NangPaGo.domain.user.auth;
 
-import com.mars.NangPaGo.domain.user.dto.RefreshTokenDto;
-import com.mars.NangPaGo.domain.user.repository.RefreshTokenRepository;
-import com.mars.NangPaGo.domain.user.util.JwtUtil;
+import com.mars.NangPaGo.domain.jwt.dto.RefreshTokenDto;
+import com.mars.NangPaGo.domain.jwt.repository.RefreshTokenRepository;
+import com.mars.NangPaGo.domain.jwt.util.JwtUtil;
 import com.mars.NangPaGo.domain.user.vo.CustomOAuth2User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/CustomLogoutService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/service/CustomLogoutService.java
@@ -1,7 +1,7 @@
 package com.mars.NangPaGo.domain.user.service;
 
-import com.mars.NangPaGo.domain.user.repository.RefreshTokenRepository;
-import com.mars.NangPaGo.domain.user.util.JwtUtil;
+import com.mars.NangPaGo.domain.jwt.repository.RefreshTokenRepository;
+import com.mars.NangPaGo.domain.jwt.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 기존처럼 `user` 도메인 하위에 token 관련 코드가 있는게 어색하지는 않은 것 같지만, token 관련 코드가 많아지면서 도메인 개념이 섞이는 것 같아 분리해보았습니다.
- 참고: https://github.com/MARS-LIKELION/NangPaGo/pull/49 PR이 먼저 merge 된 다음 리뷰가 진행되어야 합니다.

## PR 유형

- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 파일 혹은 폴더명 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

[NPG-69]: https://mars-likelion.atlassian.net/browse/NPG-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ