### PR TITLE
[NPG-46] 재료사전 search API 구현

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
@@ -25,6 +25,7 @@ public enum NPGExceptionType {
 
     // Internal Server Error(500)
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
+    SERVER_ERROR_ELASTICSEARCH(HttpStatus.INTERNAL_SERVER_ERROR, "Elasticsearch 서버 에러"),
     ;
 
     private final HttpStatus httpStatus;

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                     "/token/reissue",
                     "/auth/status",
                     "/recipe/{id}",
+                    "/ingredient/search",
                     "/common/example/**" // TODO: 제거 예정
                 ).permitAll()
                 .anyRequest().authenticated());

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/controller/IngredientElasticController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/controller/IngredientElasticController.java
@@ -1,8 +1,12 @@
 package com.mars.NangPaGo.domain.ingredient.controller;
 
+import com.mars.NangPaGo.domain.ingredient.entity.IngredientElastic;
+import com.mars.NangPaGo.domain.ingredient.service.IngredientElasticSearchService;
 import com.mars.NangPaGo.domain.ingredient.service.IngredientElasticSynchronizer;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 public class IngredientElasticController {
     private final IngredientElasticSynchronizer ingredientElasticSynchronizer;
+    private final IngredientElasticSearchService ingredientElasticSearchService;
 
     @PostMapping("/sync")
     public ResponseEntity<String> syncMysql() {
@@ -25,5 +30,10 @@ public class IngredientElasticController {
     public ResponseEntity<String> uploadCsvFile(@RequestParam("file") MultipartFile file) {
         String response = ingredientElasticSynchronizer.insertIngredientFromCsv(file);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search")
+    ResponseEntity<List<IngredientElastic>> searchByPrefix(@RequestParam("keyword") String keyword) {
+        return ResponseEntity.ok(ingredientElasticSearchService.searchByPrefix(keyword));
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/controller/IngredientElasticController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/controller/IngredientElasticController.java
@@ -1,11 +1,11 @@
 package com.mars.NangPaGo.domain.ingredient.controller;
 
+import com.mars.NangPaGo.common.dto.ResponseDto;
 import com.mars.NangPaGo.domain.ingredient.entity.IngredientElastic;
 import com.mars.NangPaGo.domain.ingredient.service.IngredientElasticSearchService;
 import com.mars.NangPaGo.domain.ingredient.service.IngredientElasticSynchronizer;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,19 +21,17 @@ public class IngredientElasticController {
     private final IngredientElasticSearchService ingredientElasticSearchService;
 
     @PostMapping("/sync")
-    public ResponseEntity<String> syncMysql() {
-        String response = ingredientElasticSynchronizer.insertIngredientFromMysql();
-        return ResponseEntity.ok(response);
+    public ResponseDto<String> syncMysql() {
+        return ResponseDto.of(ingredientElasticSynchronizer.insertIngredientFromMysql());
     }
 
     @PostMapping("/upload")
-    public ResponseEntity<String> uploadCsvFile(@RequestParam("file") MultipartFile file) {
-        String response = ingredientElasticSynchronizer.insertIngredientFromCsv(file);
-        return ResponseEntity.ok(response);
+    public ResponseDto<String> uploadCsvFile(@RequestParam("file") MultipartFile file) {
+        return ResponseDto.of(ingredientElasticSynchronizer.insertIngredientFromCsv(file));
     }
 
     @GetMapping("/search")
-    ResponseEntity<List<IngredientElastic>> searchByPrefix(@RequestParam("keyword") String keyword) {
-        return ResponseEntity.ok(ingredientElasticSearchService.searchByPrefix(keyword));
+    public ResponseDto<List<IngredientElastic>> searchByPrefix(@RequestParam("keyword") String keyword) {
+        return ResponseDto.of(ingredientElasticSearchService.searchByPrefix(keyword));
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/entity/Ingredient.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/entity/Ingredient.java
@@ -6,10 +6,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "ingredients_dictionary")
 public class Ingredient {
     @Id
@@ -18,4 +22,17 @@ public class Ingredient {
 
     @NotNull
     private String name;
+
+    @Builder
+    private Ingredient(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static Ingredient create(Long id, String name) {
+        return Ingredient.builder()
+            .id(id)
+            .name(name)
+            .build();
+    }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/entity/IngredientElastic.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/entity/IngredientElastic.java
@@ -1,38 +1,45 @@
 package com.mars.NangPaGo.domain.ingredient.entity;
 
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
 
 @Getter
-@Builder
-@Document(indexName = "ingredients_dictionary")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setting(settingPath = "elastic/ingredient/post-setting.json")
+@Mapping(mappingPath = "elastic/ingredient/post-mapping.json")
+@Document(indexName = "ingredients_dictionary", writeTypeHint = WriteTypeHint.FALSE)
 public class IngredientElastic {
     @Id
-    private String id;
+    private Long id;
 
     @Field(type = FieldType.Text)
     private String name;
 
     @Builder
-    private IngredientElastic(String id, String name) {
+    private IngredientElastic(Long id, String name) {
         this.id = id;
         this.name = name;
     }
 
     public static IngredientElastic create(String id, String name) {
         return IngredientElastic.builder()
-            .id(id)
+            .id(Long.valueOf(id))
             .name(name)
             .build();
     }
 
     public static IngredientElastic create(Long id, String name) {
         return IngredientElastic.builder()
-            .id(String.valueOf(id))
+            .id(id)
             .name(name)
             .build();
     }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/repository/IngredientElasticRepository.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/repository/IngredientElasticRepository.java
@@ -1,9 +1,7 @@
 package com.mars.NangPaGo.domain.ingredient.repository;
 
 import com.mars.NangPaGo.domain.ingredient.entity.IngredientElastic;
-import java.util.List;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface IngredientElasticRepository extends ElasticsearchRepository<IngredientElastic, String> {
-    List<IngredientElastic> findByName(String name);
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/repository/IngredientElasticRepository.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/repository/IngredientElasticRepository.java
@@ -1,7 +1,9 @@
 package com.mars.NangPaGo.domain.ingredient.repository;
 
 import com.mars.NangPaGo.domain.ingredient.entity.IngredientElastic;
+import java.util.List;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface IngredientElasticRepository extends ElasticsearchRepository<IngredientElastic, String> {
+    List<IngredientElastic> findByName(String name);
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/service/IngredientElasticSearchService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/service/IngredientElasticSearchService.java
@@ -1,0 +1,37 @@
+package com.mars.NangPaGo.domain.ingredient.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.mars.NangPaGo.common.exception.NPGExceptionType;
+import com.mars.NangPaGo.domain.ingredient.entity.IngredientElastic;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class IngredientElasticSearchService {
+    private final ElasticsearchClient elasticsearchClient;
+
+    public IngredientElasticSearchService(ElasticsearchClient elasticsearchClient) {
+        this.elasticsearchClient = elasticsearchClient;
+    }
+
+    public List<IngredientElastic> searchByPrefix(String keyword) {
+        try {
+            SearchResponse<IngredientElastic> response = elasticsearchClient.search(
+                s -> s.index("ingredients_dictionary")
+                    .query(q -> q.prefix(p -> p.field("name").value(keyword))), // 접두어 검색
+                IngredientElastic.class
+            );
+
+            return response.hits().hits().stream()
+                .map(hit -> hit.source())
+                .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw NPGExceptionType.SERVER_ERROR_ELASTICSEARCH.of("ingredients_dictionary 인덱스 접근 에러");
+        }
+    }
+}

--- a/NangPaGo-be/src/main/resources/elastic/ingredient/post-mapping.json
+++ b/NangPaGo-be/src/main/resources/elastic/ingredient/post-mapping.json
@@ -1,0 +1,12 @@
+{
+  "properties": {
+    "id": {
+      "type": "long"
+    },
+    "name": {
+      "type": "text",
+      "analyzer": "edge_ngram_analyzer",
+      "search_analyzer": "standard"
+    }
+  }
+}

--- a/NangPaGo-be/src/main/resources/elastic/ingredient/post-setting.json
+++ b/NangPaGo-be/src/main/resources/elastic/ingredient/post-setting.json
@@ -1,0 +1,24 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "edge_ngram_tokenizer": {
+        "type": "edge_ngram",
+        "min_gram": 1,
+        "max_gram": 25,
+        "token_chars": [
+          "letter",
+          "digit"
+        ]
+      }
+    },
+    "analyzer": {
+      "edge_ngram_analyzer": {
+        "type": "custom",
+        "tokenizer": "edge_ngram_tokenizer"
+      },
+      "default": {
+        "type": "standard"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 개요
### 재료사전 search API 구현 내용
- Prefix 기준으로 검색
- 예시 `GET http://localhost:8080/ingredient/search?keyword=버`

  ```json
  [
      { "id": 235,
          "name": "녹인 무염 버터" },
      { "id": 598,
          "name": "무염 버터" },
      { "id": 709,
          "name": "버거빵" },
      { "id": 710,
          "name": "버섯가루" },
      { "id": 711,
          "name": "버섯마늘소금" },
      { "id": 712,
          "name": "버터" },
      { "id": 841,
          "name": "새송이 버섯" },
      { "id": 1045,
          "name": "양송이 버섯" }
  ]
  ```

### 버그 사항 (이번 PR 후 추후 추가 구현 예정)
- 두 번 API 호출 문제: Elasticsearch 검색 쿼리가 반환되기 전에 API 호출이 이루어져 정확한 답변이 나오지 않음.
  - Total Hits Value 로 **디버깅**한 결과, 첫번째 호출 때는 쿼리 그대로 반환되고 있음을 확인
    ```
    Total Hits Value's Count(첫번째 호출): 1646
    Total Hits Value's Count(두번째 호출): 4
    ```
  - 동기/비동기 방식 검토 필요: 현재 동기/비동기 처리 방식에 대한 검토가 필요.
  - _refresh 관련: 테스트 결과, _refresh 설정은 의미가 없음.
- `ElasticsearchConfig` 파일 삭제 예정: `application.yml`에서 설정한 `spring.elasticsearch.uris`와 중복되므로, 해당 파일은 삭제해도 정상 실행됨.
- 초성/중성/종성 검색 개선: 사용자가 초성 또는 중성까지만 입력해도 해당 초성/중성/종성이 일치하는 단어가 반환되도록 개선. 예를 들어, "가"를 입력하면 "갈", "간"과 같은 단어들이 반환되어야 함.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).