### PR TITLE
[Npg-77] logout 요청 URL `/api` 접두어 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -111,4 +111,4 @@ jobs:
             sudo docker pull zooxop/nangpago-app:${{ env.VERSION }}
             sudo docker pull zooxop/nangpago-frontend:${{ env.VERSION }}
             docker-compose -p nangpago up -d
-            docker image prune -f
+            sudo docker image prune -f -a

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/GlobalExceptionHandler.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(NPGException.class)
     public ResponseEntity<Object> handleNPGException(NPGException exception) {
         if (exception.isMessageNotEmpty()) {
-            log.warn("[{}] {}", exception.getNpgExceptionType().name(), this);
+            log.warn("[{}] {}", exception.getNpgExceptionType().name(), exception.getMessage());
         }
 
         if (exception.isInternalServerError()) {

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/config/SecurityConfig.java
@@ -29,8 +29,8 @@ public class SecurityConfig {
     private String clientHost;
 
     private static final String[] WHITE_LIST = {
-        "/api/oauth2/authorization/**", // OAuth2 인증 시작점
-        "/api/login/oauth2/code/**",    // OAuth2 리다이렉트 URI
+        "/api/oauth2/authorization/**",
+        "/api/login/oauth2/code/**",
         "/api/token/reissue",
         "/api/auth/status",
         "/api/recipe/{id}",

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/auth/CustomLogoutFilter.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/auth/CustomLogoutFilter.java
@@ -42,7 +42,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
     }
 
     private boolean isLogoutRequest(HttpServletRequest request) {
-        return "/logout".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(request.getMethod());
+        return "/api/logout".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(request.getMethod());
     }
 
     private String extractRefreshToken(HttpServletRequest request) {

--- a/NangPaGo-fe/src/components/common/Header.jsx
+++ b/NangPaGo-fe/src/components/common/Header.jsx
@@ -15,7 +15,7 @@ function Header() {
 
   const handleLogout = async () => {
     try {
-      await axiosInstance.post('/logout');
+      await axiosInstance.post('/api/logout');
       dispatch(logout());
     } catch (error) {
       console.error('로그아웃 실패:', error.response?.data || error.message);


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 프론트에서 logout 요청 시 호출하는 URL에 `/api` 접두어가 빠져있어 요청을 실패하는 문제를 해결하기 위해 접두어 추가
- 그외 변경 사항 반영
  - global exception handler에서 예외 로그 출력 시, 딱히 의미없이 표시되고 있던 정보를 예외 메시지로 변경
  - 배포 Deploy 시 미사용 Docker image 삭제해주는 명령어가 동작하지 않고 있어, 옵션을 변경.

## PR 유형

- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).