### PR TITLE
[NPG-72] ElasticSearch 검색 고도화

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/controller/IngredientEsController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/controller/IngredientEsController.java
@@ -27,7 +27,8 @@ public class IngredientEsController {
     }
 
     @GetMapping("/search")
-    public ResponseDto<List<IngredientEsResponseDto>> searchByPrefix(@RequestParam("keyword") String keyword) {
+    public ResponseDto<List<IngredientEsResponseDto>> searchIngredient(
+        @RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
         return ResponseDto.of(ingredientEsService.searchIngredients(keyword));
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/service/IngredientEsSynchronizer.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/ingredient/service/IngredientEsSynchronizer.java
@@ -25,6 +25,8 @@ public class IngredientEsSynchronizer {
     @Transactional
     public String insertIngredientFromMysql() {
         try {
+            ingredientEsRepository.deleteAll();
+
             List<Ingredient> ingredientList = ingredientRepository.findAll();
             List<IngredientEs> ingredientEsList = new ArrayList<>();
             for (Ingredient ingredient : ingredientList) {

--- a/NangPaGo-be/src/main/resources/elastic/ingredient/post-setting.json
+++ b/NangPaGo-be/src/main/resources/elastic/ingredient/post-setting.json
@@ -13,16 +13,23 @@
         },
         "analyzer": {
           "my_ngram_analyzer": {
-            "tokenizer": "my_ngram_tokenizer"
+            "tokenizer": "my_ngram_tokenizer",
+            "filter": [
+              "lowercase"
+            ]
           },
           "suggest_search_analyzer": {
             "type": "custom",
-            "tokenizer": "jaso_search_tokenizer"
+            "tokenizer": "jaso_search_tokenizer",
+            "filter": [
+              "lowercase"
+            ]
           },
           "suggest_index_analyzer": {
             "type": "custom",
             "tokenizer": "jaso_index_tokenizer",
             "filter": [
+              "lowercase",
               "suggest_filter"
             ]
           }

--- a/NangPaGo-data/elastic/ingredients_dictionary/init_index_ingredients_dictionary.sh
+++ b/NangPaGo-data/elastic/ingredients_dictionary/init_index_ingredients_dictionary.sh
@@ -27,16 +27,23 @@ curl -XPUT "${ELASTICSEARCH_URI}/ingredients_dictionary?include_type_name=true&p
         },
         "analyzer": {
           "my_ngram_analyzer": {
-            "tokenizer": "my_ngram_tokenizer"
+            "tokenizer": "my_ngram_tokenizer",
+            "filter": [
+              "lowercase"
+            ]
           },
           "suggest_search_analyzer": {
             "type": "custom",
-            "tokenizer": "jaso_search_tokenizer"
+            "tokenizer": "jaso_search_tokenizer",
+            "filter": [
+              "lowercase"
+            ]
           },
           "suggest_index_analyzer": {
             "type": "custom",
             "tokenizer": "jaso_index_tokenizer",
             "filter": [
+              "lowercase",
               "suggest_filter"
             ]
           }


### PR DESCRIPTION
## 개요
- ElasticSearch 검색 고도화
  - 대소문자 구분 없는 검색 활성화
  - MySQL-ES 업로드할 시, 기존 데이터 삭제
  - keyword 파라미터 처리 방식 수정 (optional with default value '')
    - 기존의 코드는 빈 값이 들어가면, API 호출 자체가 안 되었으나, 현재는 빈 배열이 나오는 형태로 변경

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.