### PR TITLE
[NPG-92] 회원 정보 수정 페이지 UI 일부 수정,  API 연결, 모달 창 추가

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/auth/factory/userinfo/NaverUserInfo.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/auth/factory/userinfo/NaverUserInfo.java
@@ -28,10 +28,6 @@ public class NaverUserInfo implements OAuth2UserInfo {
         return getAttribute("name");
     }
 
-    public String getNickname() {
-        return getAttribute("nickname");
-    }
-
     public String getPhoneNumber() {
         return formatPhoneNumber(getAttribute("mobile"));
     }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/dto/UserRequestDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/dto/UserRequestDto.java
@@ -23,26 +23,24 @@ public record UserRequestDto(
         String updatedAt
 ) {
     public static UserRequestDto fromOAuth2UserInfo(OAuth2UserInfo userInfo) {
+        String nickname;
         String phone = "";
         String birthday = "";
-        String nickname;
         String gender = "";
 
         if (userInfo instanceof NaverUserInfo naverUserInfo) {
             phone = naverUserInfo.getPhoneNumber();
             birthday = naverUserInfo.getBirthDay();
-            nickname = naverUserInfo.getNickname();
             gender = naverUserInfo.getGender();
         } else if (userInfo instanceof KakaoUserInfo kakaoUserInfo) {
             phone = kakaoUserInfo.getPhoneNumber();
             birthday = kakaoUserInfo.getBirthday();
-            nickname = kakaoUserInfo.getName();
             gender = kakaoUserInfo.getGender();
-        } else {
-            String email = userInfo.getEmail();
-            int atIndex = email.indexOf('@');
-            nickname = email.substring(0, atIndex);
         }
+        String email = userInfo.getEmail();
+        int atIndex = email.indexOf('@');
+        nickname = email.substring(0, atIndex);
+
 
         return UserRequestDto.builder()
                 .name(userInfo.getName())

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/dto/UserRequestDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/dto/UserRequestDto.java
@@ -25,7 +25,7 @@ public record UserRequestDto(
     public static UserRequestDto fromOAuth2UserInfo(OAuth2UserInfo userInfo) {
         String phone = "";
         String birthday = "";
-        String nickname = "";
+        String nickname;
         String gender = "";
 
         if (userInfo instanceof NaverUserInfo naverUserInfo) {
@@ -38,6 +38,10 @@ public record UserRequestDto(
             birthday = kakaoUserInfo.getBirthday();
             nickname = kakaoUserInfo.getName();
             gender = kakaoUserInfo.getGender();
+        } else {
+            String email = userInfo.getEmail();
+            int atIndex = email.indexOf('@');
+            nickname = email.substring(0, atIndex);
         }
 
         return UserRequestDto.builder()

--- a/NangPaGo-fe/src/common/modal/UpdateUserInfoModal.jsx
+++ b/NangPaGo-fe/src/common/modal/UpdateUserInfoModal.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function UpdateUserInfoModal({ isOpen }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-8 rounded-lg relative flex flex-col items-center w-[calc(100% - 32px)] max-w-[400px]">
+        <p className="text-center">회원 정보를 수정하였습니다.</p>
+        <div className="mt-4 flex gap-4">
+          <button
+            onClick={() => (window.location.href = '/')}
+            className="bg-[var(--primary-color)] text-white px-5 py-3 rounded-lg"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default UpdateUserInfoModal;

--- a/NangPaGo-fe/src/components/common/Header.jsx
+++ b/NangPaGo-fe/src/components/common/Header.jsx
@@ -28,7 +28,6 @@ function Header() {
 
   const getUsername = (email) => email.split('@')[0];
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
@@ -42,7 +41,7 @@ function Header() {
   }, []);
 
   if (!loginState.isInitialized) {
-    return null; // 초기화 중에는 렌더링하지 않음
+    return null; 
   }
 
   return (
@@ -79,7 +78,7 @@ function Header() {
                   {getUsername(loginState.email)}
                 </div>
                 <Link
-                  to="/api/user/profile"
+                  to="/profile"
                   className="block px-4 py-2 text-gray-700 hover:bg-gray-100 text-[13px]"
                 >
                   마이페이지

--- a/NangPaGo-fe/src/components/common/Header.jsx
+++ b/NangPaGo-fe/src/components/common/Header.jsx
@@ -79,7 +79,7 @@ function Header() {
                   {getUsername(loginState.email)}
                 </div>
                 <Link
-                  to="/profile"
+                  to="/api/user/profile"
                   className="block px-4 py-2 text-gray-700 hover:bg-gray-100 text-[13px]"
                 >
                   마이페이지

--- a/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
+++ b/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
@@ -34,7 +34,7 @@ const UserInfoModify = () => {
     if (isLoggedIn) {
       fetchUserInfo();
     }
-  }, []);
+  }, [isLoggedIn]);
 
   const handleNicknameCheck = async () => {
     try {

--- a/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
+++ b/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
@@ -1,81 +1,85 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import { useSelector } from 'react-redux';
+import axiosInstance from '../../api/axiosInstance';
 import Header from '../common/Header';
 import Footer from '../common/Footer';
+import UpdateUserInfoModal from '../../common/modal/UpdateUserInfoModal';
 
 const UserInfoModify = () => {
   const [userInfo, setUserInfo] = useState({});
   const [nickname, setNickname] = useState('');
+  const [isNicknameAvailable, setIsNicknameAvailable] = useState(false);
+  const [isNicknameAvailableMessage, setisNicknameAvailableMessage] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const loginState = useSelector((state) => state.loginSlice);
+  const isLoggedIn = Boolean(loginState.email);
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
 
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
-        const response = await axios.get('/api/v1/members/me', {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-          },
-        });
-        setUserInfo(response.data);
-        setNickname(response.data.nickname);
-        console.log('사용자 정보:', response.data);
+        const response = await axiosInstance.get('/api/user/profile');
+        setUserInfo(response.data.data);
+        setNickname(response.data.data.nickname);
+        setisNicknameAvailableMessage('');
+        console.log('사용자 정보:', response.data.data);
       } catch (error) {
         console.error('Failed to fetch user info:', error);
       }
     };
-
-    fetchUserInfo();
+    if (isLoggedIn) {
+      fetchUserInfo();
+    }
   }, []);
 
   const handleNicknameCheck = async () => {
     try {
-      const response = await axios.get(`/api/users/checkNickname/${nickname}`);
+      const response = await axiosInstance.get(`/api/user/profile/check?nickname=${nickname}`);
       console.log('닉네임 중복 확인 응답:', response);
 
-      if (response.data.available) {
-        alert('사용 가능한 닉네임입니다.');
+      if (response.data.data) {
+        setIsNicknameAvailable(true);
+        setisNicknameAvailableMessage('사용 가능한 닉네임입니다.');
       } else {
-        alert('이미 사용 중인 닉네임입니다.');
+        setIsNicknameAvailable(false);
+        setisNicknameAvailableMessage('사용할 수 없는 닉네임입니다.');
       }
     } catch (error) {
       console.error('닉네임 중복 확인 실패:', error);
-      alert('닉네임 중복 확인에 실패했습니다.');
+      setisNicknameAvailableMessage('닉네임 중복 확인에 실패했습니다.');
     }
   };
 
   const handleSubmit = async () => {
+    if (!isNicknameAvailable) {
+      setisNicknameAvailableMessage('닉네임 중복 확인을 해주세요.');
+      return;
+    }
+
     try {
-      await axios.patch(
-        '/api/v1/members/me',
-        { nickname },
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-          },
-        },
-      );
-      alert('회원정보가 수정되었습니다.');
+      const userInfoRequestDto = {
+      nickname: nickname, // nickname 상태에서 가져옴
+    };
+      await axiosInstance.put('/api/user/profile', userInfoRequestDto);
+      setIsModalOpen(true);
     } catch (error) {
       console.error('Failed to update user info:', error);
     }
   };
 
   return (
-    <div className="bg-white mx-auto w-[375px] min-h-screen flex flex-col justify-between">
-      <div>
+    <div className="bg-white mx-auto w-[375px] min-h-screen flex flex-col">
+      <div className="flex-grow">
         <Header />
         <div className="px-6 bg-white">
           <h3 className="text-xl font-bold mb-6 text-gray-800 text-center">
             회원정보 수정
           </h3>
           <div>
-            <div className="mb-4">
-              <label className="block text-gray-700 mb-2">이름</label>
-              <input
-                type="text"
-                value={userInfo.name || ''}
-                className="w-full p-2 border border-gray-300 rounded"
-              />
-            </div>
             <div className="mb-4">
               <label className="block text-gray-500 mb-2">닉네임 (필수)</label>
               <div className="flex gap-2">
@@ -92,41 +96,33 @@ const UserInfoModify = () => {
                   중복 확인
                 </button>
               </div>
+              {isNicknameAvailableMessage && (
+                <p className={`mt-2 ${isNicknameAvailable ? 'text-green-600' : 'text-red-600'}`}>
+                  {isNicknameAvailableMessage}
+                </p>
+              )}
             </div>
             <div className="mb-4">
               <label className="block text-gray-500 mb-2">이메일 (필수)</label>
               <input
                 type="email"
                 value={userInfo.email}
-                className="w-full p-2 rounded border border-gray-300"
+                className="w-full p-2 rounded border border-gray-F bg-gray-200"
                 disabled
               />
             </div>
-            <div className="mt-6">
-              <div className="text-gray-500 mb-2">계정 정보</div>
-              <div className="border-t border-yellow-400">
-                <div className="flex justify-between py-2 border-b">
-                  <span className="text-gray-600">연결 계정</span>
-                  <span className="text-gray-800">
-                    {userInfo.provider === 'NAVER'
-                      ? '네이버'
-                      : userInfo.provider === 'KAKAO'
-                        ? '카카오'
-                        : userInfo.provider === 'GOOGLE'
-                          ? '구글'
-                          : ''}
-                  </span>
-                </div>
-              </div>
-            </div>
-            <button
-              onClick={handleSubmit}
-              className="w-full bg-yellow-400 text-white py-2 rounded mt-6"
-            >
-              회원정보 저장하기
-            </button>
           </div>
         </div>
+      </div>
+      <div className="px-6 mb-6 mt-auto">
+        <button
+          onClick={handleSubmit}
+          className={`w-full py-2 rounded mt-6 ${isNicknameAvailable ? 'bg-yellow-400 text-white' : 'bg-yellow-200 text-white cursor-not-allowed'}`}
+          disabled={!isNicknameAvailable}
+        >
+          회원정보 저장하기
+        </button>
+        <UpdateUserInfoModal isOpen={isModalOpen} onClose={handleCloseModal} />
       </div>
       <Footer />
     </div>

--- a/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
+++ b/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
@@ -62,7 +62,7 @@ const UserInfoModify = () => {
 
     try {
       const userInfoRequestDto = {
-      nickname: nickname, // nickname 상태에서 가져옴
+      nickname: nickname, 
     };
       await axiosInstance.put('/api/user/profile', userInfoRequestDto);
       setIsModalOpen(true);

--- a/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
+++ b/NangPaGo-fe/src/components/mypage/UserInfoModify.jsx
@@ -9,7 +9,7 @@ const UserInfoModify = () => {
   const [userInfo, setUserInfo] = useState({});
   const [nickname, setNickname] = useState('');
   const [isNicknameAvailable, setIsNicknameAvailable] = useState(false);
-  const [isNicknameAvailableMessage, setisNicknameAvailableMessage] = useState('');
+  const [isNicknameAvailableMessage, setIsNicknameAvailableMessage] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const loginState = useSelector((state) => state.loginSlice);
@@ -25,7 +25,7 @@ const UserInfoModify = () => {
         const response = await axiosInstance.get('/api/user/profile');
         setUserInfo(response.data.data);
         setNickname(response.data.data.nickname);
-        setisNicknameAvailableMessage('');
+        setIsNicknameAvailableMessage('');
         console.log('사용자 정보:', response.data.data);
       } catch (error) {
         console.error('Failed to fetch user info:', error);
@@ -41,22 +41,36 @@ const UserInfoModify = () => {
       const response = await axiosInstance.get(`/api/user/profile/check?nickname=${nickname}`);
       console.log('닉네임 중복 확인 응답:', response);
 
+      const validations = [
+        { condition: !nickname || nickname.trim().length === 0, message: '빈 값은 닉네임으로 사용할 수 없습니다.' },
+        { condition: nickname.includes(" "), message: '닉네임에 공백이 포함될 수 없습니다.' },
+        { condition: nickname.length <= 1, message: '닉네임은 두글자 이상이여야 합니다.' },
+      ];
+
+      for (const validation of validations) {
+        if (validation.condition) {
+            setIsNicknameAvailable(false);
+            setIsNicknameAvailableMessage(validation.message);
+            return;
+        }
+      }
+
       if (response.data.data) {
         setIsNicknameAvailable(true);
-        setisNicknameAvailableMessage('사용 가능한 닉네임입니다.');
+        setIsNicknameAvailableMessage('사용 가능한 닉네임입니다.');
       } else {
         setIsNicknameAvailable(false);
-        setisNicknameAvailableMessage('사용할 수 없는 닉네임입니다.');
+        setIsNicknameAvailableMessage('이미 사용중인 닉네임입니다.');
       }
     } catch (error) {
       console.error('닉네임 중복 확인 실패:', error);
-      setisNicknameAvailableMessage('닉네임 중복 확인에 실패했습니다.');
+      setIsNicknameAvailableMessage('닉네임 중복 확인에 실패했습니다.');
     }
   };
 
   const handleSubmit = async () => {
     if (!isNicknameAvailable) {
-      setisNicknameAvailableMessage('닉네임 중복 확인을 해주세요.');
+      setIsNicknameAvailableMessage('닉네임 중복 확인을 해주세요.');
       return;
     }
 
@@ -81,7 +95,7 @@ const UserInfoModify = () => {
           </h3>
           <div>
             <div className="mb-4">
-              <label className="block text-gray-500 mb-2">닉네임 (필수)</label>
+              <label className="block text-gray-500 mb-2">닉네임</label>
               <div className="flex gap-2">
                 <input
                   type="text"
@@ -103,7 +117,7 @@ const UserInfoModify = () => {
               )}
             </div>
             <div className="mb-4">
-              <label className="block text-gray-500 mb-2">이메일 (필수)</label>
+              <label className="block text-gray-500 mb-2">이메일</label>
               <input
                 type="email"
                 value={userInfo.email}

--- a/NangPaGo-fe/src/routes/Router.jsx
+++ b/NangPaGo-fe/src/routes/Router.jsx
@@ -17,7 +17,7 @@ const router = createBrowserRouter([
     element: <Login />,
   },
   {
-    path: '/api/user/profile',
+    path: '/profile',
     element: <UserInfoModify />,
   },
   {

--- a/NangPaGo-fe/src/routes/Router.jsx
+++ b/NangPaGo-fe/src/routes/Router.jsx
@@ -17,7 +17,7 @@ const router = createBrowserRouter([
     element: <Login />,
   },
   {
-    path: '/my-page/modify',
+    path: '/api/user/profile',
     element: <UserInfoModify />,
   },
   {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 기존 구현 UI에 연동 계정 종류(구글,네이버) 제거
- alert부분을 메세지로 변경
- 닉네임 중복 체크 확인여부로 회원 정보 수정 버튼 비활성화 및 마진 위치 변경
- 회원 정보 가져오기, 중복 닉네임 검사, 회원 정보수정 API 연결
- 회원 정보 수정 버튼 클릭 시 나올 모달창 추가

## PR 유형

- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).