### PR TITLE
[NO-ISSUE] Service 레이어 테스트 유틸리티 구조 개선 (인증 관련)

### DIFF
--- a/NangPaGo-be/src/test/java/com/mars/NangPaGo/domain/recipe/service/RecipeLikeServiceTest.java
+++ b/NangPaGo-be/src/test/java/com/mars/NangPaGo/domain/recipe/service/RecipeLikeServiceTest.java
@@ -1,7 +1,9 @@
 package com.mars.NangPaGo.domain.recipe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.mars.NangPaGo.common.exception.NPGException;
 import com.mars.NangPaGo.domain.recipe.dto.RecipeLikeResponseDto;
 import com.mars.NangPaGo.domain.recipe.entity.Recipe;
 import com.mars.NangPaGo.domain.recipe.entity.RecipeLike;
@@ -90,21 +92,24 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
             .isEqualTo(false);
     }
 
-//    @DisplayName("유저가 레시피에 좋아요를 클릭할때 SecurityContext의 email과 DB의 유저 email이 일치하지 않을 경우 예외처리")
-//    @Test
-//    void NotCorrectUserException() {
-//        // given
-//        setUp();
-//
-//        // mocking
-//        when(userRepository.findByEmail(anyString())).thenThrow(new NPGException(NOT_FOUND_USER));
-//
-//        // then
-//        assertThatThrownBy(() -> recipeLikeService.toggleLike(recipeId, email))
-//            .isInstanceOf(NPGException.class)
-//            .hasMessage("사용자를 찾을 수 없습니다.");
-//    }
-//
+    @DisplayName("좋아요를 클릭한 유저의 이메일을 찾을 수 없을 때 예외를 발생시킬 수 있다.")
+    @Test
+    void notFoundUserException() {
+        // given
+        String email = "nonExistent@nangpago.com";
+        Recipe recipe = createRecipe("파스타");
+        recipeRepository.save(recipe);
+
+        setAuthenticationAsUserWithToken(email);
+
+        Long recipeId = recipe.getId();
+
+        // when & then
+        assertThatThrownBy(() -> recipeLikeService.toggleLike(recipeId, email))
+            .isInstanceOf(NPGException.class)
+            .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
 //    @DisplayName("유저가 레시피에 좋아요를 클릭할때 레시피 ID를 못받는 경우 예외처리")
 //    @Test
 //    void NotFoundRecipeException() {

--- a/NangPaGo-be/src/test/java/com/mars/NangPaGo/domain/recipe/service/RecipeLikeServiceTest.java
+++ b/NangPaGo-be/src/test/java/com/mars/NangPaGo/domain/recipe/service/RecipeLikeServiceTest.java
@@ -97,13 +97,13 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
     @Test
     void notFoundUserException() {
         // given
-        String email = "nonExistent@nangpago.com";
+        User user = createUser("nonExistent@nangpago.com");
+        setAuthenticationAsUserWithToken(user.getEmail());
         Recipe recipe = createRecipe("파스타");
         recipeRepository.save(recipe);
 
-        setAuthenticationAsUserWithToken(email);
-
         Long recipeId = recipe.getId();
+        String email = user.getEmail();
 
         // when & then
         assertThatThrownBy(() -> recipeLikeService.toggleLike(recipeId, email))
@@ -111,38 +111,84 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
             .hasMessage("사용자를 찾을 수 없습니다.");
     }
 
-//    @DisplayName("유저가 레시피에 좋아요를 클릭할때 레시피 ID를 못받는 경우 예외처리")
-//    @Test
-//    void NotFoundRecipeException() {
-//        // given
-//        setUp();
-//        RecipeLike recipeLike = RecipeLike.of(user, recipe);
-//
-//        // mocking
-//        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
-//        when(recipeRepository.findById(anyLong())).thenThrow(new NPGException(NOT_FOUND_RECIPE));
-//
-//        // when, then
-//        assertThatThrownBy(() -> recipeLikeService.toggleLike(recipeId, email))
-//            .isInstanceOf(NPGException.class)
-//            .hasMessage("레시피를 찾을 수 없습니다.");
-//    }
-//
-//    @DisplayName("이미 좋아요를 누른 레시피는 RecipeLike 엔티티를 조회할 수 있다.")
-//    @Test
-//    void isLikedByUser() {
-//        // given
-//        setUp();
-//        RecipeLike recipeLike = RecipeLike.of(user, recipe);
-//
-//        // mocking
-//        when(recipeLikeRepository.findByEmailAndRecipeId(anyString(), anyLong())).thenReturn(
-//            Optional.ofNullable(recipeLike));
-//
-//        // when
-//        boolean liked = recipeLikeService.isLikedByRecipe(recipeId, email);
-//
-//        // then
-//        assertThat(liked).isTrue();
-//    }
+    @DisplayName("recipeId 로 레시피를 찾을 수 없을 때 예외를 발생시킬 수 있다.")
+    @Test
+    void notFoundRecipeException() {
+        // given
+        User user = createUser("example@nangpago.com");
+        userRepository.save(user);
+
+        String email = user.getEmail();
+
+        // when & then
+        assertThatThrownBy(() -> recipeLikeService.toggleLike(1L, email))
+            .isInstanceOf(NPGException.class)
+            .hasMessage("레시피를 찾을 수 없습니다.");
+    }
+
+    @DisplayName("좋아요를 누른 레시피는 좋아요 상태가 true 이다.")
+    @Test
+    void isLikedByUser() {
+        // given
+        User user = createUser("example@nangpago.com");
+        Recipe recipe = createRecipe("파스타");
+
+        userRepository.save(user);
+        recipeRepository.save(recipe);
+
+        RecipeLike recipeLike = RecipeLike.builder()
+            .user(user)
+            .recipe(recipe)
+            .build();
+
+        recipeLikeRepository.save(recipeLike);
+
+        // when
+        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user.getEmail());
+
+        // then
+        assertThat(isLiked).isTrue();
+    }
+
+    @DisplayName("좋아요를 누르지 않은 레시피는 좋아요 상태가 false 이다.")
+    @Test
+    void isNotLikedByUser() {
+        // given
+        User user = createUser("example@nangpago.com");
+        Recipe recipe = createRecipe("파스타");
+
+        userRepository.save(user);
+        recipeRepository.save(recipe);
+
+        // when
+        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user.getEmail());
+
+        // then
+        assertThat(isLiked).isFalse();
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 좋아요한 레시피에 대해 현재 사용자의 좋아요 상태는 false 이다.")
+    void isLikedByDifferentUser() {
+        // given
+        User user1 = createUser("user1@nangpago.com");
+        User user2 = createUser("user2@nangpago.com");
+        Recipe recipe = createRecipe("파스타");
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+        recipeRepository.save(recipe);
+
+        RecipeLike recipeLike = RecipeLike.builder()
+            .user(user1)
+            .recipe(recipe)
+            .build();
+        recipeLikeRepository.save(recipeLike);
+
+        // when
+        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user2.getEmail());
+
+        // then
+        assertThat(isLiked).isFalse();
+    }
 }

--- a/NangPaGo-be/src/test/java/com/mars/NangPaGo/domain/recipe/service/RecipeLikeServiceTest.java
+++ b/NangPaGo-be/src/test/java/com/mars/NangPaGo/domain/recipe/service/RecipeLikeServiceTest.java
@@ -51,7 +51,7 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
     }
 
     @Transactional
-    @DisplayName("유저가 레시피에 좋아요를 클릭하여 RecipeLike 추가")
+    @DisplayName("레시피 좋아요를 클릭할 수 있다.")
     @Test
     void addRecipeLike() {
         // given
@@ -71,7 +71,8 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
         assertThat(recipeLikeResponseDto.recipeId()).isEqualTo(recipe.getId());
     }
 
-    @DisplayName("이미 좋아요를 누른 레시피에서 유저가 레시피에 좋아요를 클릭하여 RecipeLike 삭제")
+    @Transactional
+    @DisplayName("레시피 좋아요를 취소할 수 있다.")
     @Test
     void cancelRecipeLike() {
         // given

--- a/NangPaGo-be/src/test/java/com/mars/NangPaGo/provider/TestJwtProvider.java
+++ b/NangPaGo-be/src/test/java/com/mars/NangPaGo/provider/TestJwtProvider.java
@@ -1,0 +1,21 @@
+package com.mars.NangPaGo.provider;
+
+import com.mars.NangPaGo.common.util.JwtUtil;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestJwtProvider {
+    private final JwtUtil jwtUtil;
+
+    public TestJwtProvider(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String createTestAccessToken(String email, String role) {
+        return jwtUtil.createJwt("access", email, role, 3600000L); // 1시간
+    }
+
+    public String createTestRefreshToken(String email, String role) {
+        return jwtUtil.createJwt("refresh", email, role, 86400000L); // 24시간
+    }
+}

--- a/NangPaGo-be/src/test/java/com/mars/NangPaGo/support/IntegrationTestSupport.java
+++ b/NangPaGo-be/src/test/java/com/mars/NangPaGo/support/IntegrationTestSupport.java
@@ -1,17 +1,48 @@
 package com.mars.NangPaGo.support;
 
 import com.google.firebase.FirebaseApp;
+import com.mars.NangPaGo.common.util.JwtUtil;
+import com.mars.NangPaGo.provider.TestJwtProvider;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
+    @Autowired
+    private TestJwtProvider testJwtProvider;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
     @BeforeAll
     static void setUp() {
         // 테스트 시작 전 기존 Firebase 인스턴스 정리
         FirebaseApp.getApps().forEach(FirebaseApp::delete);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    protected void setAuthenticationAsUserWithToken(String email) {
+        setAuthenticationWithToken(email, "ROLE_USER");
+    }
+
+    protected void setAuthenticationAsAdminWithToken(String email) {
+        setAuthenticationWithToken(email, "ROLE_ADMIN");
+    }
+
+    private void setAuthenticationWithToken(String email, String role) {
+        String token = testJwtProvider.createTestAccessToken(email, role);
+        Authentication authentication = jwtUtil.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 테스트 코드에서 임의의 인증된 Access Token을 발급할 수 있는 기능 추가
  - `IntegrationTestSupport` 를 사용하는 Service 레이어 테스트 시 사용
- RecipeLikeService 테스트 케이스 추가

## PR 유형

- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).