### PR TITLE
[NPG-127] 레시피 리스트 응답에 좋아요, 댓글 집계 추가

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/recipe/dto/RecipeEsResponseDto.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/recipe/dto/RecipeEsResponseDto.java
@@ -10,17 +10,25 @@ public record RecipeEsResponseDto(
     String name,
     String highlightedName,
     String recipeImageUrl,
+    int likeCount,
+    int commentCount,
     List<String> ingredients,
     List<String> ingredientsTag,
     List<String> ingredientsDisplayTag,
     float matchScore
 ) {
-    public static RecipeEsResponseDto of(RecipeEs recipeEs, String highlightedName, float score) {
+    public static RecipeEsResponseDto of(RecipeEs recipeEs,
+                                         String highlightedName,
+                                         int likeCount,
+                                         int commentCount,
+                                         float score) {
         return RecipeEsResponseDto.builder()
             .id(recipeEs.getId())
             .name(recipeEs.getName())
             .highlightedName(highlightedName)
             .recipeImageUrl(recipeEs.getRecipeImageUrl())
+            .likeCount(likeCount)
+            .commentCount(commentCount)
             .ingredients(recipeEs.getIngredients())
             .ingredientsTag(recipeEs.getIngredientsTag())
             .ingredientsDisplayTag(recipeEs.getIngredientsDisplayTag())

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/recipe/service/RecipeEsService.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/recipe/service/RecipeEsService.java
@@ -4,9 +4,11 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.mars.NangPaGo.common.exception.NPGExceptionType;
+import com.mars.NangPaGo.domain.comment.recipe.repository.RecipeCommentRepository;
 import com.mars.NangPaGo.domain.recipe.builder.EsRecipeSearchQueryBuilder;
 import com.mars.NangPaGo.domain.recipe.dto.RecipeEsResponseDto;
 import com.mars.NangPaGo.domain.recipe.entity.RecipeEs;
+import com.mars.NangPaGo.domain.recipe.repository.RecipeLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -22,6 +24,8 @@ import java.util.Optional;
 public class RecipeEsService {
 
     private final ElasticsearchClient elasticsearchClient;
+    private final RecipeLikeRepository recipeLikeRepository;
+    private final RecipeCommentRepository recipeCommentRepository;
 
     public Page<RecipeEsResponseDto> searchRecipes(int page, int size, String keyword, String searchType) {
         Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(size, 1));
@@ -66,12 +70,33 @@ public class RecipeEsService {
                     .map(highlights -> highlights.get(0))
                     .orElse(source.getName());
 
+                int likeCount = getRecipeLikeCountBy(source.getId());
+                int commentCount = getRecipeCommentCountBy(source.getId());
+
                 return RecipeEsResponseDto.of(
                     source,
                     highlightedName,
+                    likeCount,
+                    commentCount,
                     hit.score() != null ? hit.score().floatValue() : 0.0f
                 );
             })
             .toList();
+    }
+
+    private int getRecipeLikeCountBy(String recipeId) {
+        try {
+            return recipeLikeRepository.countByRecipeId(Long.parseLong(recipeId));
+        } catch (Exception e) {
+            throw NPGExceptionType.SERVER_ERROR.of("String type recipeId parse to Long is failed (recipeLike)");
+        }
+    }
+
+    private int getRecipeCommentCountBy(String recipeId) {
+        try {
+            return recipeCommentRepository.countByRecipeId(Long.parseLong(recipeId));
+        } catch (Exception e) {
+            throw NPGExceptionType.SERVER_ERROR.of("String type recipeId parse to Long is failed (recipeComment)");
+        }
     }
 }

--- a/NangPaGo-fe/src/api/commentService.js
+++ b/NangPaGo-fe/src/api/commentService.js
@@ -20,8 +20,3 @@ export const updateComment = (recipeId, commentId, commentData) =>
 
 export const deleteComment = (recipeId, commentId) =>
   axiosInstance.delete(`/api/recipe/${recipeId}/comments/${commentId}`);
-
-export const fetchCommentCount = (recipeId) =>
-  axiosInstance
-    .get(`/api/recipe/${recipeId}/comments/count`)
-    .then((response) => response.data.data);

--- a/NangPaGo-fe/src/components/recipe/RecipeCard.jsx
+++ b/NangPaGo-fe/src/components/recipe/RecipeCard.jsx
@@ -1,35 +1,8 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getLikeCount } from '../../api/recipe';
 import { AiFillHeart } from 'react-icons/ai';
 import { FaCommentAlt } from 'react-icons/fa';
-import { fetchCommentCount } from '../../api/commentService';
 
 function RecipeCard({ recipe }) {
-  const [likeCount, setLikeCount] = useState(0);
-  const [commentCount, setCommentCount] = useState(0);
-
-  useEffect(() => {
-    const fetchCounts = async () => {
-      try {
-        const [likeCountData, commentCountData] = await Promise.all([
-          getLikeCount(recipe.id),
-          fetchCommentCount(recipe.id),
-        ]);
-
-        setLikeCount(likeCountData || 0);
-        setCommentCount(commentCountData || 0);
-      } catch (error) {
-        console.error(
-          '좋아요 또는 댓글 데이터를 가져오는 중 오류 발생:',
-          error,
-        );
-      }
-    };
-
-    fetchCounts();
-  }, [recipe.id]);
-
   return (
     <Link
       to={`/recipe/${recipe.id}`}
@@ -44,11 +17,11 @@ function RecipeCard({ recipe }) {
         <div className="text-sm text-gray-600 flex items-center gap-4">
           <div className="flex items-center gap-1">
             <AiFillHeart className="text-red-500 text-xl" />
-            {likeCount}
+            {recipe.likeCount}
           </div>
           <div className="flex items-center gap-1">
             <FaCommentAlt className="text-gray-300 text-xl" />
-            {commentCount}
+            {recipe.commentCount}
           </div>
         </div>
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- count 조회를 위해 과도하게 API를 요청하지 않도록, recipe search API 응답에 좋아요 및 댓글 개수를 추가.

## PR 유형

- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).