### PR TITLE
[NO-ISSUE] 마이페이지 탭 조회 버그 수정

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/NPGExceptionType.java
@@ -15,6 +15,7 @@ public enum NPGExceptionType {
     BAD_REQUEST_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 요청"),
     BAD_REQUEST_INVALID_COMMENT(HttpStatus.BAD_REQUEST, "댓글 내용은 비어 있을 수 없습니다."),
     BAD_REQUEST_INVALID_PAGE_NO(HttpStatus.BAD_REQUEST, "pageNo 는 양수로 입력해야 합니다."),
+    BAD_REQUEST_INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "pageSize 는 양수로 입력해야 합니다."),
     BAD_REQUSET_CHECK_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임 중복 검사를 해야합니다."),
     BAD_REQUEST_UNUSABLE_NICKNAME(HttpStatus.BAD_REQUEST, "사용할 수 없는 닉네임입니다."),
 

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/recipe/controller/RecipeController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/recipe/controller/RecipeController.java
@@ -59,16 +59,19 @@ public class RecipeController {
 
     @GetMapping("/search")
     public ResponseDto<Page<RecipeEsResponseDto>> searchRecipes(
-        @RequestParam(name = "pageNo", defaultValue = "1") int page,
-        @RequestParam(name = "pageSize", defaultValue = "10") int size,
+        @RequestParam(name = "pageNo", defaultValue = "1") int pageNo,
+        @RequestParam(name = "pageSize", defaultValue = "10") int pageSize,
         @RequestParam(name = "keyword", required = false) String keyword,
         @RequestParam(name = "searchType", defaultValue = "INGREDIENTS") String searchType) {
 
-        if (page < 1) {
-            throw NPGExceptionType.BAD_REQUEST_INVALID_COMMENT.of();
+        if (pageNo < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_NO.of();
+        }
+        if (pageSize < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
         }
 
-        return ResponseDto.of(recipeEsService.searchRecipes(page - 1, size, keyword, searchType));
+        return ResponseDto.of(recipeEsService.searchRecipes(pageNo - 1, pageSize, keyword, searchType));
     }
 
     @PostMapping("/bulk-upload/mysql")

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/controller/UserController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.mars.NangPaGo.common.aop.auth.AuthenticatedUser;
 import com.mars.NangPaGo.common.component.auth.AuthenticationHolder;
 import com.mars.NangPaGo.common.dto.PageDto;
 import com.mars.NangPaGo.common.dto.ResponseDto;
+import com.mars.NangPaGo.common.exception.NPGExceptionType;
 import com.mars.NangPaGo.domain.comment.recipe.dto.RecipeCommentResponseDto;
 import com.mars.NangPaGo.domain.favorite.recipe.dto.RecipeFavoriteListResponseDto;
 import com.mars.NangPaGo.domain.recipe.dto.RecipeResponseDto;
@@ -65,8 +66,15 @@ public class UserController {
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "7") int pageSize
     ) {
+        if (pageNo < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_NO.of();
+        }
+        if (pageSize < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
+        }
+
         String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getMyLikedRecipes(email, pageNo, pageSize));
+        return ResponseDto.of(userService.getMyLikedRecipes(email, pageNo - 1, pageSize));
     }
 
     @AuthenticatedUser
@@ -75,8 +83,15 @@ public class UserController {
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "7") int pageSize
     ) {
+        if (pageNo < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_NO.of();
+        }
+        if (pageSize < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
+        }
+
         String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getMyFavorites(email, pageNo, pageSize));
+        return ResponseDto.of(userService.getMyFavorites(email, pageNo - 1, pageSize));
     }
 
     @AuthenticatedUser
@@ -85,7 +100,14 @@ public class UserController {
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "7") int pageSize
     ) {
+        if (pageNo < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_NO.of();
+        }
+        if (pageSize < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
+        }
+
         String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getMyComments(email, pageNo, pageSize));
+        return ResponseDto.of(userService.getMyComments(email, pageNo - 1, pageSize));
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 마이페이지 하단 탭 전환 시, `pageNo` 값을 잘못 넣어서 조회하는 버그를 수정함.
- 탭 전환 이벤트에 debounce 를 먹여서, 빠르게 여러 탭을 전환해도 마지막 한번만 요청이 나가도록 하였음.

## PR 유형

- [x] 버그 수정
- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).