### PR TITLE
[NPG-134] 메인과 상세 뷰의 이미지 레이아웃 통일

### DIFF
--- a/NangPaGo-fe/src/components/common/Image.jsx
+++ b/NangPaGo-fe/src/components/common/Image.jsx
@@ -1,5 +1,5 @@
 export const styles = {
   imageList: 'w-full h-48 object-cover',
-  mainImage: 'w-full h-full object-contain rounded-md',
-  detailImage: 'w-full h-full object-contain mt-2 rounded-md',
+  mainImage: 'w-full h-full rounded-md',
+  detailImage: 'w-full h-full mb-6 rounded-md',
 };

--- a/NangPaGo-fe/src/components/common/Image.jsx
+++ b/NangPaGo-fe/src/components/common/Image.jsx
@@ -1,0 +1,5 @@
+export const styles = {
+  imageList: 'w-full h-48 object-cover',
+  mainImage: 'w-full h-48 object-contain rounded-md',
+  detailImage: 'w-full h-40 object-contain mt-2 rounded-md',
+};

--- a/NangPaGo-fe/src/components/common/Image.jsx
+++ b/NangPaGo-fe/src/components/common/Image.jsx
@@ -1,5 +1,5 @@
 export const styles = {
   imageList: 'w-full h-48 object-cover',
-  mainImage: 'w-full h-48 object-contain rounded-md',
-  detailImage: 'w-full h-40 object-contain mt-2 rounded-md',
+  mainImage: 'w-full h-full object-contain rounded-md',
+  detailImage: 'w-full h-full object-contain mt-2 rounded-md',
 };

--- a/NangPaGo-fe/src/components/community/Community.jsx
+++ b/NangPaGo-fe/src/components/community/Community.jsx
@@ -7,6 +7,7 @@ import Header from '../common/Header';
 import Footer from '../common/Footer';
 import { getLikeCount } from '../../api/community.js';
 import CreateButton from '../common/CreateButton';
+import { styles } from '../common/Image'
 
 const maskEmail = (email) => {
   if (!email) return '';
@@ -94,7 +95,7 @@ function Community({ community }) {
           <img
             src={community.imageUrl}
             alt={community.title}
-            className="w-full h-48 object-cover rounded-md"
+            className={styles.mainImage}
           />
         </div>
 

--- a/NangPaGo-fe/src/components/community/CommunityCard.jsx
+++ b/NangPaGo-fe/src/components/community/CommunityCard.jsx
@@ -1,0 +1,36 @@
+import { AiFillHeart } from 'react-icons/ai';
+import { FaCommentAlt } from 'react-icons/fa';
+import { styles } from '../../components/common/Image';
+
+function CommunityCard({ item, onClick }) {
+  return (
+    <li
+      className="border rounded-lg overflow-hidden shadow-md flex flex-col cursor-pointer"
+      onClick={() => onClick(item.id)}
+    >
+      {/* 이미지 */}
+      <img
+        src={item.imageUrl}
+        alt={item.title}
+        className={styles.imageList}
+      />
+      {/* 텍스트 */}
+      <div className="p-4 space-y-2">
+        <div className="flex items-center gap-4 text-gray-600">
+          <div className="flex items-center gap-1">
+            <AiFillHeart className="text-red-500 text-lg" />
+            <span>{item.likeCount}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <FaCommentAlt className="text-gray-500 text-lg" />
+            <span>{item.commentCount}</span>
+          </div>
+        </div>
+        <h2 className="text-lg font-semibold truncate">{item.title}</h2>
+        <p className="text-sm text-gray-500 line-clamp-2">{item.content}</p>
+      </div>
+    </li>
+  );
+}
+
+export default CommunityCard;

--- a/NangPaGo-fe/src/components/community/FileUpload.jsx
+++ b/NangPaGo-fe/src/components/community/FileUpload.jsx
@@ -1,3 +1,5 @@
+import { styles } from '../common/Image'
+
 function FileUpload({ file, onChange, imagePreview }) {
   return (
     <div className="flex flex-col items-center mb-4">
@@ -9,7 +11,7 @@ function FileUpload({ file, onChange, imagePreview }) {
           <img
             src={imagePreview}
             alt="Uploaded Preview"
-            className="w-full h-full object-cover"
+            className={styles.mainImage}
           />
         ) : (
           <span className="text-gray-400">사진 업로드</span>

--- a/NangPaGo-fe/src/components/recipe/CookingSteps.jsx
+++ b/NangPaGo-fe/src/components/recipe/CookingSteps.jsx
@@ -1,3 +1,5 @@
+import { styles } from '../common/Image'
+
 function CookingSteps({ steps, stepImages }) {
   return (
     <div className="cooking-steps mt-1">
@@ -8,7 +10,7 @@ function CookingSteps({ steps, stepImages }) {
             <img
               src={stepImages[index].imageUrl}
               alt={`Step ${index + 1}`}
-              className="w-full h-40 object-cover mt-2 rounded-md"
+              className={styles.detailImage}
             />
           )}
         </div>

--- a/NangPaGo-fe/src/components/recipe/Recipe.jsx
+++ b/NangPaGo-fe/src/components/recipe/Recipe.jsx
@@ -8,6 +8,7 @@ import RecipeComment from './comment/RecipeComment';
 import Header from '../common/Header';
 import Footer from '../common/Footer';
 import { getLikeCount } from '../../api/recipe.js';
+import { styles } from '../common/Image'
 
 function Recipe({ recipe }) {
   const { email: userEmail } = useSelector((state) => state.loginSlice);
@@ -89,7 +90,7 @@ function Recipe({ recipe }) {
           <img
             src={recipe.mainImage}
             alt={recipe.name}
-            className="w-full h-48 object-cover rounded-md"
+            className={styles.mainImage}
           />
         </div>
 

--- a/NangPaGo-fe/src/components/recipe/RecipeCard.jsx
+++ b/NangPaGo-fe/src/components/recipe/RecipeCard.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { AiFillHeart } from 'react-icons/ai';
 import { FaCommentAlt } from 'react-icons/fa';
+import { styles } from '../common/Image'
 
 function RecipeCard({ recipe }) {
   return (
@@ -11,7 +12,7 @@ function RecipeCard({ recipe }) {
       <img
         src={recipe.recipeImageUrl}
         alt={recipe.name}
-        className="w-full h-48 object-cover"
+        className={styles.imageList}
       />
       <div className="p-4 flex flex-col gap-2">
         <div className="text-sm text-gray-600 flex items-center gap-4">

--- a/NangPaGo-fe/src/pages/community/CommunityList.jsx
+++ b/NangPaGo-fe/src/pages/community/CommunityList.jsx
@@ -7,6 +7,7 @@ import TopButton from '../../components/common/TopButton';
 import CreateButton from '../../components/common/CreateButton';
 import Header from '../../components/common/Header';
 import Footer from '../../components/common/Footer';
+import CommunityCard from '../../components/community/CommunityCard';
 
 function CommunityList() {
   const [communityList, setCommunityList] = useState([]);
@@ -86,38 +87,12 @@ function CommunityList() {
       <div className="flex-grow px-4 space-y-4">
         {
           <ul className="space-y-4">
-            {communityList.map((item) => (
-              <li
-                key={item.id}
-                className="border rounded-lg overflow-hidden shadow-md flex flex-col cursor-pointer"
-                onClick={() => handleCardClick(item.id)}
-              >
-                {/* 이미지 */}
-                <img
-                  src={item.imageUrl}
-                  alt={item.title}
-                  className="w-full h-48 object-cover"
-                />
-                {/* 텍스트 */}
-                <div className="p-4 space-y-2">
-                  <div className="flex items-center gap-4 text-gray-600">
-                    <div className="flex items-center gap-1">
-                      <AiFillHeart className="text-red-500 text-lg" />
-                      <span>{item.likeCount}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <FaCommentAlt className="text-gray-500 text-lg" />
-                      <span>{item.commentCount}</span>
-                    </div>
-                  </div>
-                  <h2 className="text-lg font-semibold truncate">
-                    {item.title}
-                  </h2>
-                  <p className="text-sm text-gray-500 line-clamp-2">
-                    {item.content}
-                  </p>
-                </div>
-              </li>
+            {communityList.map((community) => (
+              <CommunityCard
+                key={community.id}
+                item={community}
+                onClick={handleCardClick}
+              />
             ))}
             <div ref={observerRef} className="h-4"></div>
           </ul>


### PR DESCRIPTION
## 개요
### (Chore) 메인과 상세 뷰의 이미지 레이아웃 통일
- 이미지 클래스 타입 공통화: `components/common/Image.jsx`
  ```jsx
  export const styles = {
    imageList: 'w-full h-48 object-cover', // 조회 페이지의 경우, 고정된 height 값
    mainImage: 'w-full h-full rounded-md', // 상세 페이지의 경우, 이미지 원본 그대로
    detailImage: 'w-full h-full mb-6 rounded-md', // 상세 페이지의 경우, 이미지 원본 그대로
  };
  ```
- 렌더링 로직 분리: `components/community/CommunityCard.jsx` 생성하여 레이아웃 처리

## PR 유형

- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).