### PR TITLE
[NPG-149] 커뮤니티 게시물: 이미지 취소 버튼 추가

### DIFF
--- a/NangPaGo-fe/src/components/community/FileUpload.jsx
+++ b/NangPaGo-fe/src/components/community/FileUpload.jsx
@@ -1,6 +1,11 @@
-import { styles } from '../common/Image'
+import { styles } from '../common/Image';
 
-function FileUpload({ file, onChange, imagePreview }) {
+function FileUpload({ file, onChange, imagePreview, onCancel }) {
+  const handleCancel = (e) => {
+    e.preventDefault();
+    onCancel();
+  };
+
   return (
     <div className="flex flex-col items-center mb-4">
       <label
@@ -8,11 +13,20 @@ function FileUpload({ file, onChange, imagePreview }) {
         className="w-full h-40 border border-gray-300 rounded-md flex items-center justify-center bg-gray-100 cursor-pointer relative overflow-hidden"
       >
         {imagePreview ? (
-          <img
-            src={imagePreview}
-            alt="Uploaded Preview"
-            className={styles.mainImage}
-          />
+          <>
+            <img
+              src={imagePreview}
+              alt="Uploaded Preview"
+              className={`${styles.mainImage} object-contain`}
+            />
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="absolute top-2 right-2 bg-gray-400 text-white w-6 h-6 flex items-center justify-center rounded-full z-10 text-base opacity-70"
+            >
+              x
+            </button>
+          </>
         ) : (
           <span className="text-gray-400">사진 업로드</span>
         )}
@@ -22,6 +36,7 @@ function FileUpload({ file, onChange, imagePreview }) {
           accept="image/*"
           className="absolute inset-0 opacity-0 cursor-pointer"
           onChange={onChange}
+          key={file ? file.name : 'file-upload'}
         />
       </label>
     </div>

--- a/NangPaGo-fe/src/pages/community/CreateCommunity.jsx
+++ b/NangPaGo-fe/src/pages/community/CreateCommunity.jsx
@@ -30,10 +30,14 @@ function CreateCommunity() {
 
   const handleFileChange = (e) => {
     const selectedFile = e.target.files[0];
-    if (selectedFile) {
+    if (selectedFile && selectedFile !== file) {
       setFile(selectedFile);
-      setImagePreview(URL.createObjectURL(selectedFile));
     }
+  };
+
+  const handleCancel = () => {
+    setFile(null);
+    setImagePreview(null);
   };
 
   const handleSubmit = async () => {
@@ -71,6 +75,7 @@ function CreateCommunity() {
           file={file}
           onChange={handleFileChange}
           imagePreview={imagePreview}
+          onCancel={handleCancel}
         />
         <TextArea
           value={content}

--- a/NangPaGo-fe/src/pages/community/ModifyCommunity.jsx
+++ b/NangPaGo-fe/src/pages/community/ModifyCommunity.jsx
@@ -9,6 +9,8 @@ import FileUpload from '../../components/community/FileUpload';
 import ErrorMessage from '../../components/common/ErrorMessage';
 import SubmitButton from '../../components/common/SubmitButton';
 
+const DEFAULT_IMAGE_URL = "https://storage.googleapis.com/nangpago-9d371.firebasestorage.app/dc137676-6240-4920-97d3-727c4b7d6d8d_360_F_517535712_q7f9QC9X6TQxWi6xYZZbMmw5cnLMr279.jpg";
+
 function ModifyCommunity() {
   const navigate = useNavigate();
   const { id } = useParams();
@@ -32,7 +34,11 @@ function ModifyCommunity() {
         setTitle(data.title);
         setContent(data.content);
         setIsPublic(data.isPublic);
-        if (data.imageUrl) setImagePreview(data.imageUrl);
+        if (data.imageUrl && data.imageUrl !== DEFAULT_IMAGE_URL) {
+          setImagePreview(data.imageUrl);
+        } else {
+          setImagePreview(null);
+        }
       } catch (err) {
         console.error('게시글 데이터를 가져오는 중 오류 발생:', err);
         setError('게시글 데이터를 불러오는 중 문제가 발생했습니다.');
@@ -51,10 +57,14 @@ function ModifyCommunity() {
 
   const handleFileChange = (e) => {
     const selectedFile = e.target.files[0];
-    if (selectedFile) {
+    if (selectedFile && selectedFile !== file) {
       setFile(selectedFile);
-      setImagePreview(URL.createObjectURL(selectedFile));
     }
+  };
+
+  const handleCancel = () => {
+    setFile(null);
+    setImagePreview(null);
   };
 
   const handleSubmit = async () => {
@@ -90,6 +100,7 @@ function ModifyCommunity() {
           file={file}
           onChange={handleFileChange}
           imagePreview={imagePreview}
+          onCancel={handleCancel}
         />
         <TextArea
           value={content}


### PR DESCRIPTION
## 개요
### 게시물 작성 페이지 - 이미지 취소 버튼 추가 (파일 선택 후 취소 시, 파일과 미리보기를 초기화)
1. `e.preventDefault()` 추가: <label> 클릭 시 기본 파일 선택 동작을 방지.
2. (BUG) 기본 이미지 미표시: 게시물 수정 시 `imagePreview`가 `null`이면 기본 이미지가 표시되지 않도록 처리.
3. (BUG) 파일 변경 시 상태 업데이트: `selectedFile !== file`로 파일 변경 시에만 상태를 업데이트하여 불필요한 렌더링을 방지.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).