### PR TITLE
[NPG-140] 커뮤니티 게시글 예외 발생 메시지 전달 구조 개선

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/GlobalExceptionHandler.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,16 @@
 package com.mars.NangPaGo.common.exception;
 
+import static com.mars.NangPaGo.common.exception.NPGExceptionType.BAD_REQUEST;
+
 import com.mars.NangPaGo.common.dto.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -25,5 +31,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         ResponseDto<String> responseDto = ResponseDto.of("", exception.getMessage());
 
         return ResponseEntity.status(httpStatus).body(responseDto);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+        HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        String message = ex.getBindingResult().getAllErrors().stream()
+            .findFirst()
+            .get().getDefaultMessage();
+
+        return ResponseEntity.badRequest().body(ResponseDto.of("", message));
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/community/controller/CommunityController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/community/controller/CommunityController.java
@@ -1,5 +1,7 @@
 package com.mars.NangPaGo.domain.community.controller;
 
+import static com.mars.NangPaGo.common.exception.NPGExceptionType.BAD_REQUEST;
+
 import com.mars.NangPaGo.common.aop.auth.AuthenticatedUser;
 import com.mars.NangPaGo.common.component.auth.AuthenticationHolder;
 import com.mars.NangPaGo.common.dto.PageDto;
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
@@ -51,9 +54,16 @@ public class CommunityController {
     @AuthenticatedUser
     @PostMapping
     public ResponseDto<CommunityResponseDto> create(
-        @ModelAttribute @Valid CommunityRequestDto requestDto,
+        @ModelAttribute @Valid CommunityRequestDto requestDto, BindingResult bindingResult,
         @RequestParam(value = "file", required = false) MultipartFile file
-        ) {
+    ) {
+
+        if (bindingResult.hasErrors()) {
+            bindingResult.getFieldErrors().forEach(error -> {
+                String message = error.getDefaultMessage();
+                throw BAD_REQUEST.of(message);
+            });
+        }
 
         String email = AuthenticationHolder.getCurrentUserEmail();
         return ResponseDto.of(communityService.createCommunity(requestDto, file, email), "게시물이 성공적으로 생성되었습니다.");
@@ -63,9 +73,17 @@ public class CommunityController {
     @AuthenticatedUser
     @PutMapping("/{id}")
     public ResponseDto<CommunityResponseDto> update(
-        @ModelAttribute @Valid CommunityRequestDto requestDto,
+        @ModelAttribute @Valid CommunityRequestDto requestDto,BindingResult bindingResult,
         @RequestParam(value = "file", required = false) MultipartFile file,
         @PathVariable("id") Long id) {
+
+        if (bindingResult.hasErrors()) {
+            bindingResult.getFieldErrors().forEach(error -> {
+                //Dto의 유효성 검증을 하면서 에러 발생 시 validation 관련 어노테이션에 작성한 message를 담아 반환합니다.
+                String message = error.getDefaultMessage();
+                throw BAD_REQUEST.of(message);
+            });
+        }
 
         String email = AuthenticationHolder.getCurrentUserEmail();
         return ResponseDto.of(communityService.updateCommunity(id, requestDto, file, email), "게시물이 성공적으로 수정되었습니다.");

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/community/controller/CommunityController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/community/controller/CommunityController.java
@@ -54,11 +54,9 @@ public class CommunityController {
     @AuthenticatedUser
     @PostMapping
     public ResponseDto<CommunityResponseDto> create(
-        @ModelAttribute @Valid CommunityRequestDto requestDto, BindingResult bindingResult,
+        @ModelAttribute @Valid CommunityRequestDto requestDto,
         @RequestParam(value = "file", required = false) MultipartFile file
     ) {
-
-        checkValidateError(bindingResult);
 
         String email = AuthenticationHolder.getCurrentUserEmail();
         return ResponseDto.of(communityService.createCommunity(requestDto, file, email), "게시물이 성공적으로 생성되었습니다.");
@@ -68,11 +66,9 @@ public class CommunityController {
     @AuthenticatedUser
     @PutMapping("/{id}")
     public ResponseDto<CommunityResponseDto> update(
-        @ModelAttribute @Valid CommunityRequestDto requestDto,BindingResult bindingResult,
+        @ModelAttribute @Valid CommunityRequestDto requestDto,
         @RequestParam(value = "file", required = false) MultipartFile file,
         @PathVariable("id") Long id) {
-
-        checkValidateError(bindingResult);
 
         String email = AuthenticationHolder.getCurrentUserEmail();
         return ResponseDto.of(communityService.updateCommunity(id, requestDto, file, email), "게시물이 성공적으로 수정되었습니다.");
@@ -85,15 +81,5 @@ public class CommunityController {
         String email = AuthenticationHolder.getCurrentUserEmail();
         communityService.deleteCommunity(id, email);
         return ResponseDto.of(null, "게시물이 성공적으로 삭제되었습니다.");
-    }
-
-    private void checkValidateError(BindingResult bindingResult){
-        if (bindingResult.hasErrors()) {
-            bindingResult.getFieldErrors().forEach(error -> {
-                //Dto의 유효성 검증을 하면서 에러 발생 시 validation 관련 어노테이션에 작성한 message를 담아 반환합니다.
-                String message = error.getDefaultMessage();
-                throw BAD_REQUEST.of(message);
-            });
-        }
     }
 }

--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/community/controller/CommunityController.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/domain/community/controller/CommunityController.java
@@ -58,12 +58,7 @@ public class CommunityController {
         @RequestParam(value = "file", required = false) MultipartFile file
     ) {
 
-        if (bindingResult.hasErrors()) {
-            bindingResult.getFieldErrors().forEach(error -> {
-                String message = error.getDefaultMessage();
-                throw BAD_REQUEST.of(message);
-            });
-        }
+        checkValidateError(bindingResult);
 
         String email = AuthenticationHolder.getCurrentUserEmail();
         return ResponseDto.of(communityService.createCommunity(requestDto, file, email), "게시물이 성공적으로 생성되었습니다.");
@@ -77,13 +72,7 @@ public class CommunityController {
         @RequestParam(value = "file", required = false) MultipartFile file,
         @PathVariable("id") Long id) {
 
-        if (bindingResult.hasErrors()) {
-            bindingResult.getFieldErrors().forEach(error -> {
-                //Dto의 유효성 검증을 하면서 에러 발생 시 validation 관련 어노테이션에 작성한 message를 담아 반환합니다.
-                String message = error.getDefaultMessage();
-                throw BAD_REQUEST.of(message);
-            });
-        }
+        checkValidateError(bindingResult);
 
         String email = AuthenticationHolder.getCurrentUserEmail();
         return ResponseDto.of(communityService.updateCommunity(id, requestDto, file, email), "게시물이 성공적으로 수정되었습니다.");
@@ -96,5 +85,15 @@ public class CommunityController {
         String email = AuthenticationHolder.getCurrentUserEmail();
         communityService.deleteCommunity(id, email);
         return ResponseDto.of(null, "게시물이 성공적으로 삭제되었습니다.");
+    }
+
+    private void checkValidateError(BindingResult bindingResult){
+        if (bindingResult.hasErrors()) {
+            bindingResult.getFieldErrors().forEach(error -> {
+                //Dto의 유효성 검증을 하면서 에러 발생 시 validation 관련 어노테이션에 작성한 message를 담아 반환합니다.
+                String message = error.getDefaultMessage();
+                throw BAD_REQUEST.of(message);
+            });
+        }
     }
 }

--- a/NangPaGo-fe/src/api/community.js
+++ b/NangPaGo-fe/src/api/community.js
@@ -37,6 +37,10 @@ export const createCommunity = async (data, file) => {
     });
     return response.data;
   } catch (error) {
+    if (error.response?.data?.message) {
+      throw new Error(`${error.response.data.message}`);
+    }
+
     throw new Error(
       `커뮤니티를 생성하는 중 오류가 발생했습니다: ${error.message}`,
     );
@@ -48,6 +52,9 @@ export const updateCommunity = async (id, data) => {
     const response = await axiosInstance.put(`/api/community/${id}`, data);
     return response.data;
   } catch (error) {
+    if (error.response?.data?.message) {
+      throw new Error(`${error.response.data.message}`);
+    }
     throw new Error(
       `커뮤니티를 수정하는 중 오류가 발생했습니다: ${error.message}`,
     );

--- a/NangPaGo-fe/src/pages/community/CreateCommunity.jsx
+++ b/NangPaGo-fe/src/pages/community/CreateCommunity.jsx
@@ -54,7 +54,7 @@ function CreateCommunity() {
       }
     } catch (err) {
       console.error('게시글 등록 중 오류 발생:', err);
-      setError('게시글 등록 중 문제가 발생했습니다.');
+      setError(err.message);
     }
   };
 

--- a/NangPaGo-fe/src/pages/community/ModifyCommunity.jsx
+++ b/NangPaGo-fe/src/pages/community/ModifyCommunity.jsx
@@ -73,7 +73,7 @@ function ModifyCommunity() {
       navigate(`/community/${id}`);
     } catch (err) {
       console.error('게시글 수정 중 오류 발생:', err);
-      setError('게시글 수정 중 문제가 발생했습니다.');
+      setError(err.message);
     }
   };
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존에는 예외처리는 되어있으나 맞지않는 에러문구를 보여주었고,
그래서 백엔드에서 알맞는 에러문구를 보내주고, 프론트에 그대로 보여줄 수 있도록 하였습니다.

컨트롤러의 `@Valid`된 Dto의 validation 관련 어노테이션의 메시지를 가져와 프론트에서 보여주도록 했습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).