### PR TITLE
[NO-ISSUE] 중복 이메일 회원가입 방지 로직 에러

### DIFF
--- a/NangPaGo-be/src/main/java/com/mars/NangPaGo/auth/handler/OAuth2SuccessHandler.java
+++ b/NangPaGo-be/src/main/java/com/mars/NangPaGo/auth/handler/OAuth2SuccessHandler.java
@@ -56,7 +56,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> NOT_FOUND_USER.of("사용자 검증 에러: " + email));
 
-        if (isEmailAlreadyRegisteredForSignUp(user, provider, response)) {
+        if (isEmailAlreadyRegisteredForSignUp(user, provider)) {
+            redirectToErrorPage(response, user.getOauth2Provider().name());
             return;
         }
 
@@ -65,14 +66,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.sendRedirect(clientHost);
     }
 
-    private boolean isEmailAlreadyRegisteredForSignUp(User user, String provider, HttpServletResponse response) throws IOException {
-        if (!user.getOauth2Provider().name().equals(provider)) {
-            String existingProvider = user.getOauth2Provider().name();
-            redirectToErrorPage(response, existingProvider);
-            return true;
-        }
-
-        return false;
+    private boolean isEmailAlreadyRegisteredForSignUp(User user, String provider) {
+        return !user.getOauth2Provider().name().equals(provider);
     }
 
     private void redirectToErrorPage(HttpServletResponse response, String existingProvider) throws IOException {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 이전 PR에서, 이미 존재하는 이메일 & 다른 Provider로 회원가입을 시도하는 경우에 대한 방어 로직이 잘못 수정된 내용을 고칩니다.

## PR 유형

- [x] 버그 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).