### PR TITLE
[NPG-160] 리액트 라우팅에서 비로그인 사용자 접근 제한

### DIFF
--- a/NangPaGo/NangPaGo-app/frontend/src/components/layout/header/Header.jsx
+++ b/NangPaGo/NangPaGo-app/frontend/src/components/layout/header/Header.jsx
@@ -70,7 +70,7 @@ function Header({ isBlocked = false }) {
 
   return (
     <header className="sticky top-0 z-10 bg-white shadow-md w-full px-1 py-2 mb-4">
-      <div className="flex flex-row items-center justify-between">
+      <div className="flex flex-row items-center justify-between px-4">
         <div className="flex items-center justify-center w-17 h-17">
           <img
             src="/logo.png"
@@ -79,42 +79,45 @@ function Header({ isBlocked = false }) {
             onClick={() => handleLinkClick('/')}
           />
         </div>
-        {loginState.isLoggedIn ? (
-            <div className="grid grid-cols-3 gap-5 items-center">
-              <NavItem
-                to="/community"
-                isActive={isActive('/community')}
-                label="커뮤니티"
-                Icon={BsFilePost}
-                onClick={() => handleLinkClick('/community')}
-              />
-              <NavItem
-                to="/refrigerator"
-                isActive={isActive('/refrigerator')}
-                label="냉장고"
-                Icon={CgSmartHomeRefrigerator}
-                onClick={() => handleLinkClick('/refrigerator')}
-              />
-              <ProfileDropdown
-                dropdownRef={dropdownRef}
-                dropdownOpen={dropdownOpen}
-                toggleDropdown={toggleDropdown}
-                handleLogout={handleLogout}
-                handleLinkClick={handleLinkClick}
-                isActive={isActive('/my-page')}
-                icon={FaRegUser}
-                nickname={loginState.nickname}
-              />
-          </div>
-        ) : (
-          <button
-            to="/login"
-            onClick={() => handleLinkClick('/login')}
-            className="bg-primary text-white px-4 py-2 mr-3 rounded-md text-sm shadow-md"
-          >
-            로그인
-          </button>
-        )}
+        <div className="flex items-center justify-center space-x-4">
+          {loginState.isLoggedIn && (
+            <NavItem
+              to="/refrigerator"
+              isActive={isActive('/refrigerator')}
+              label="냉장고"
+              Icon={CgSmartHomeRefrigerator}
+              onClick={() => handleLinkClick('/refrigerator')}
+            />
+          )}
+
+          <NavItem
+            to="/community"
+            isActive={isActive('/community')}
+            label="커뮤니티"
+            Icon={BsFilePost}
+            onClick={() => handleLinkClick('/community')}
+          />
+          {loginState.isLoggedIn ? (
+            <ProfileDropdown
+              dropdownRef={dropdownRef}
+              dropdownOpen={dropdownOpen}
+              toggleDropdown={toggleDropdown}
+              handleLogout={handleLogout}
+              handleLinkClick={handleLinkClick}
+              isActive={isActive('/my-page')}
+              icon={FaRegUser}
+              nickname={loginState.nickname}
+            />
+          ) : (
+            <NavItem
+              to="/login"
+              isActive={isActive('/login')}
+              label="로그인"
+              Icon={FaRegUser}
+              onClick={() => handleLinkClick('/login')}
+            />
+          )}
+        </div>
       </div>
     </header>
   );

--- a/NangPaGo/NangPaGo-app/frontend/src/components/layout/header/Header.jsx
+++ b/NangPaGo/NangPaGo-app/frontend/src/components/layout/header/Header.jsx
@@ -32,8 +32,10 @@ function Header({ isBlocked = false }) {
 
     try {
       await axiosInstance.post('/api/logout');
-      window.location.href = '/';
       dispatch(logout());
+      setTimeout(() => {
+        navigate('/');
+      }, 0);
     } catch (error) {
       console.error('로그아웃 실패:', error.response?.data || error.message);
     }
@@ -89,7 +91,6 @@ function Header({ isBlocked = false }) {
               onClick={() => handleLinkClick('/refrigerator')}
             />
           )}
-
           <NavItem
             to="/community"
             isActive={isActive('/community')}

--- a/NangPaGo/NangPaGo-app/frontend/src/pages/error/UnauthenticatedAccess.jsx
+++ b/NangPaGo/NangPaGo-app/frontend/src/pages/error/UnauthenticatedAccess.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function UnauthenticatedAccess() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-8 rounded-lg relative flex flex-col items-center max-w-[300px] w-[calc(100%-32px)]">
+        <p className="text-center text-lg font-semibold text-gray-600 mb-2">
+          로그인 후 이용해주세요
+        </p>
+        <p className="text-center text-sm text-gray-500">
+          이 페이지에 접근하려면<br />로그인이 필요합니다.<br />로그인 후 다시 시도해주세요.
+        </p>
+        <Link
+          to="/login"
+          className="mt-4 bg-primary text-white px-5 py-3 rounded-lg"
+        >
+          로그인 페이지로 이동
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default UnauthenticatedAccess;

--- a/NangPaGo/NangPaGo-app/frontend/src/routes/AuthenticatedRoute.jsx
+++ b/NangPaGo/NangPaGo-app/frontend/src/routes/AuthenticatedRoute.jsx
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+
+const AuthenticatedRoute = ({ children }) => {
+  const { isLoggedIn, isInitialized } = useSelector((state) => state.loginSlice || {});
+
+  if (!isInitialized) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-gray"></div>
+      </div>
+    );
+  }
+
+  if (!isLoggedIn) {
+    return <Navigate to="/unauthenticated" replace />;
+  }
+
+  return children;
+};
+
+export default AuthenticatedRoute;

--- a/NangPaGo/NangPaGo-app/frontend/src/routes/Router.jsx
+++ b/NangPaGo/NangPaGo-app/frontend/src/routes/Router.jsx
@@ -12,6 +12,9 @@ import CommunityDetail from '../pages/community/CommunityDetail';
 import CreateCommunity from '../pages/community/CreateCommunity.jsx';
 import ModifyCommunity from '../pages/community/ModifyCommunity.jsx';
 import OAuthError from '../pages/error/OAuthError.jsx';
+import AuthenticatedRoute from './AuthenticatedRoute';
+import UnauthenticatedAccess from '../pages/error/UnauthenticatedAccess';
+
 const router = createBrowserRouter([
   {
     path: '/',
@@ -23,11 +26,11 @@ const router = createBrowserRouter([
   },
   {
     path: '/my-page',
-    element: <Profile />,
+    element: <AuthenticatedRoute><Profile /></AuthenticatedRoute>,
   },
   {
     path: '/my-page/modify',
-    element: <Modify />,
+    element: <AuthenticatedRoute><Modify /></AuthenticatedRoute>,
   },
   {
     path: '/recipe',
@@ -47,15 +50,15 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <Refrigerator />,
+        element: <AuthenticatedRoute><Refrigerator /></AuthenticatedRoute>,
       },
       {
         path: 'recipe',
-        element: <Refrigerator />,
+        element: <AuthenticatedRoute><Refrigerator /></AuthenticatedRoute>,
       },
       {
         path: 'search',
-        element: <RefrigeratorSearch />,
+        element: <AuthenticatedRoute><RefrigeratorSearch /></AuthenticatedRoute>,
       },
     ],
   },
@@ -72,17 +75,21 @@ const router = createBrowserRouter([
       },
       {
         path: 'new',
-        element: <CreateCommunity />,
+        element: <AuthenticatedRoute><CreateCommunity /></AuthenticatedRoute>,
       },
       {
         path: ':id/modify',
-        element: <ModifyCommunity />,
+        element: <AuthenticatedRoute><ModifyCommunity /></AuthenticatedRoute>,
       },
     ],
   },
   {
     path: '/oauth/error',
     element: <OAuthError />,
+  },
+  {
+    path: '/unauthenticated',
+    element: <UnauthenticatedAccess />,
   },
 ]);
 

--- a/NangPaGo/NangPaGo-app/frontend/src/slices/loginSlice.js
+++ b/NangPaGo/NangPaGo-app/frontend/src/slices/loginSlice.js
@@ -28,8 +28,8 @@ export const fetchUserStatus = createAsyncThunk(
 );
 
 const loadState = () => {
-  const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
-  return { isLoggedIn };
+  const isLoggedIn = localStorage.getItem('isLoggedIn');
+  return { isLoggedIn: isLoggedIn === 'true' };
 };
 
 const initialState = {
@@ -51,6 +51,7 @@ const loginSlice = createSlice({
       state.isLoggedIn = false;
       state.status = 'idle';
       state.error = null;
+      state.isInitialized = true;
       localStorage.removeItem('isLoggedIn');
     },
   },
@@ -72,6 +73,7 @@ const loginSlice = createSlice({
         state.status = 'failed';
         state.error = action.payload;
         state.isInitialized = true;
+        state.isLoggedIn = false;
         localStorage.removeItem('isLoggedIn');
       });
   },


### PR DESCRIPTION
## 개요
### 리액트 라우팅에서 비로그인 사용자 접근 제한
#### 1. 헤더 UI 변경
- 로그인 `버튼`에서 `아이콘`으로 변경
  | **변경 전** | **변경 후**        |
  |-----------------|---------------------------|
  | <img width="96" alt="image" src="https://github.com/user-attachments/assets/f5cc5aff-2cd0-4e65-81cf-9de24b6d3fad" /> | <img width="56" alt="image" src="https://github.com/user-attachments/assets/8c07d750-7ca2-4c59-81ab-949d3b121154" /> | 

- 비로그인 사용자에 대한 헤더에 '커뮤니티' 아이콘을 추가
  | **비로그인 사용자** | **로그인 사용자**        |
  |-----------------|---------------------------|
  | <img width="138" alt="image" src="https://github.com/user-attachments/assets/284265e2-2d21-48b4-8534-eac87f1673c8" /> | <img width="192" alt="image" src="https://github.com/user-attachments/assets/49d23209-78f0-4cac-9455-2976df9a8ae7" />  |

#### 2. 사용자 유형별 페이지 접근 제한
- **비로그인 사용자**가 `접근 제한된 페이지`에 이동하려는 경우, 자동으로 '/unauthenticated' 페이지로 리디렉션
  > 접근 제한 페이지 대상: `/my-page`, `/my-page/modify`, `/refrigerator`, `/community/new`, `/community/modify`

- **로그인 상태**에서 `접근 제한된 페이지`로 이동한 후 **로그아웃**을 하면, 자동으로 '/' 페이지로 리디렉션
  > `setTimeout`을 이용해 해결
    ```bash
    잘못된 흐름: 상태 변경 (로그아웃) → 리디렉션 (navigate('/')) → 렌더링 (진행 중) → 상태 반영 전 → `/unauthenticated` 로 이동
    올바른 흐름: 상태 변경 (로그아웃) → 렌더링 (진행 중 `setTimeout`) → 상태 반영 완료 → 리디렉션 (navigate('/')) → `/` 로 이동
    ```

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).