### PR TITLE
[NPG-162] 즐겨찾기 페이지 처리 및 좋아요/댓글수 표시

### DIFF
--- a/NangPaGo/NangPaGo-app/frontend/src/api/recipe.js
+++ b/NangPaGo/NangPaGo-app/frontend/src/api/recipe.js
@@ -61,27 +61,21 @@ export const fetchRecommendedRecipes = async (
   }
 };
 
-export const fetchFavoriteRecipes = async (
-  page = 0,
-  size = 10,
-  sort = 'createdAt,desc',
-) => {
+export const fetchFavoriteRecipes = async (page, size) => {
   try {
-    const response = await axiosInstance.get('/api/recipe/favorite/list', {
-      params: { page, size, sort },
-    });
-    return response.data.data;
-  } catch (error) {
-    console.error('Error fetching favorite recipes:', error);
-    return {
-      content: [],
-      currentPage: 0,
-      totalPages: 0,
-      totalItems: 0,
-      isLast: true,
+    const params = {
+      pageNo: page,
+      pageSize: size,
     };
+    const response = await axiosInstance.get('/api/recipe/favorite/list', { params });
+    const { content, last, number } = response.data.data;
+    return { content: content || [], last, number };
+  } catch (error) {
+    console.error('즐겨찾기한 레시피 목록 조회 실패:', error);
+    return { content: [], last: true, number: page };
   }
 };
+
 
 export const getLikeCount = async (recipeId) => {
   try {

--- a/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/controller/RecipeFavoriteController.java
+++ b/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/controller/RecipeFavoriteController.java
@@ -7,6 +7,7 @@ import com.mars.app.component.auth.AuthenticationHolder;
 import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteListResponseDto;
 import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteResponseDto;
 import com.mars.app.domain.favorite.recipe.service.RecipeFavoriteService;
+import com.mars.common.exception.NPGExceptionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -40,9 +41,17 @@ public class RecipeFavoriteController {
     @Operation(summary = "즐겨찾기 목록 조회")
     @AuthenticatedUser
     @GetMapping("/favorite/list")
-    public ResponseDto<PageDto<RecipeFavoriteListResponseDto>> getFavoriteRecipes(Pageable pageable) {
+    public ResponseDto<PageDto<RecipeFavoriteListResponseDto>> getFavoriteRecipes(
+        @RequestParam(defaultValue = "0") int pageNo,
+        @RequestParam(defaultValue = "7") int pageSize
+    ) {
+        if (pageNo < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_NO.of();
+        }
+        if (pageSize < 1) {
+            throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
+        }
         String email = AuthenticationHolder.getCurrentUserEmail();
-        PageDto<RecipeFavoriteListResponseDto> favoriteRecipes = recipeFavoriteService.getFavoriteRecipes(email, pageable);
-        return ResponseDto.of(favoriteRecipes);
+        return ResponseDto.of(recipeFavoriteService.getFavoriteRecipes(email, pageNo - 1, pageSize));
     }
 }

--- a/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/dto/RecipeFavoriteListResponseDto.java
+++ b/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/dto/RecipeFavoriteListResponseDto.java
@@ -9,15 +9,19 @@ import java.util.List;
 public record RecipeFavoriteListResponseDto(
     String id,
     String name,
+    int likeCount,
+    int commentCount,
     String recipeImageUrl,
     List<String> ingredients,
     List<String> ingredientsTag,
     List<String> ingredientsDisplayTag
 ) {
-    public static RecipeFavoriteListResponseDto of(Recipe recipe) {
+    public static RecipeFavoriteListResponseDto of(Recipe recipe, int likeCount, int commentCount) {
         return RecipeFavoriteListResponseDto.builder()
             .id(recipe.getId().toString())
             .name(recipe.getName())
+            .likeCount(likeCount)
+            .commentCount(commentCount)
             .recipeImageUrl(recipe.getMainImage())
             .ingredients(List.of(recipe.getIngredients().split(",")))
             .ingredientsTag(List.of(recipe.getIngredients().split(",")))

--- a/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteService.java
+++ b/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteService.java
@@ -1,5 +1,7 @@
 package com.mars.app.domain.favorite.recipe.service;
 
+import com.mars.app.domain.comment.recipe.repository.RecipeCommentRepository;
+import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
 import com.mars.common.dto.PageDto;
 import com.mars.common.exception.NPGExceptionType;
 import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteListResponseDto;
@@ -12,6 +14,7 @@ import com.mars.common.model.user.User;
 import com.mars.app.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +27,8 @@ public class RecipeFavoriteService {
     private final RecipeFavoriteRepository recipeFavoriteRepository;
     private final RecipeRepository recipeRepository;
     private final UserRepository userRepository;
+    private final RecipeLikeRepository recipeLikeRepository;
+    private final RecipeCommentRepository recipeCommentRepository;
 
     @Transactional
     public RecipeFavoriteResponseDto toggleFavorite(Long recipeId, String email) {
@@ -36,10 +41,18 @@ public class RecipeFavoriteService {
         return recipeFavoriteRepository.findByEmailAndRecipeId(email, recipeId).isPresent();
     }
 
-    public PageDto<RecipeFavoriteListResponseDto> getFavoriteRecipes(String email, Pageable pageable) {
-        Page<RecipeFavorite> favorites = recipeFavoriteRepository.findAllByUser(findUserByEmail(email), pageable);
+    public PageDto<RecipeFavoriteListResponseDto> getFavoriteRecipes(String email, int pageNo, int pageSize) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of);
+
         return PageDto.of(
-            favorites.map(favorite -> RecipeFavoriteListResponseDto.of(favorite.getRecipe()))
+            recipeFavoriteRepository.findAllByUser(user, PageRequest.of(pageNo, pageSize))
+                .map(favorite -> {
+                    Recipe recipe = favorite.getRecipe();
+                    int likeCount = recipeLikeRepository.countByRecipeId(recipe.getId());
+                    int commentCount = recipeCommentRepository.countByRecipeId(recipe.getId());
+                    return RecipeFavoriteListResponseDto.of(recipe, likeCount, commentCount);
+                })
         );
     }
 

--- a/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserService.java
+++ b/NangPaGo/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.mars.common.dto.user.MyPageDto;
 import com.mars.common.dto.user.UserInfoRequestDto;
 import com.mars.common.dto.user.UserInfoResponseDto;
 import com.mars.common.dto.user.UserResponseDto;
+import com.mars.common.model.recipe.Recipe;
 import com.mars.common.model.user.User;
 import com.mars.app.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +66,12 @@ public class UserService {
     public PageDto<RecipeFavoriteListResponseDto> getMyFavorites(String email, int pageNo, int pageSize) {
         return PageDto.of(
             recipeFavoriteRepository.findAllByUser(findUserByEmail(email), PageRequest.of(pageNo, pageSize))
-                .map(recipeFavorite -> RecipeFavoriteListResponseDto.of(recipeFavorite.getRecipe()))
+                .map(recipeFavorite -> {
+                    Recipe recipe = recipeFavorite.getRecipe();
+                    int likeCount = recipeLikeRepository.countByRecipeId(recipe.getId());
+                    int commentCount = recipeCommentRepository.countByRecipeId(recipe.getId());
+                    return RecipeFavoriteListResponseDto.of(recipe, likeCount, commentCount);
+                })
         );
     }
 

--- a/NangPaGo/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
+++ b/NangPaGo/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
@@ -138,7 +138,7 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
 
         // when
         PageDto<RecipeFavoriteListResponseDto> recipeFavorites = recipeFavoriteService.getFavoriteRecipes(
-            user.getEmail(), null);
+            user.getEmail(), 0, 10);
 
         //then
         assertThat(recipeFavorites)


### PR DESCRIPTION
## 개요
### 메인화면의 즐겨찾기탭 
-  페이지 번호 처리로 수정 및 조회
-  즐겨찾기한 레시피의 좋아요수와 댓글수 표시

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).