### PR TITLE
[NPG-195] 식재료 추가가 안되는 버그 수정

### DIFF
--- a/NangPaGo-client/src/components/util/stringUtil.jsx
+++ b/NangPaGo-client/src/components/util/stringUtil.jsx
@@ -12,8 +12,10 @@ function parseHighlightedName(htmlString) {
   });
 }
 
-function stripHtmlTags(htmlString) {
-  return htmlString.replace(/<[^>]+>/g, '');
+function stripHtmlTags(result) {
+  const htmlString = result.highlightedName;
+
+  return htmlString.replace(/<em[^>]*>(.*?)<\/em>/g, '$1');
 }
 
 export { parseHighlightedName, stripHtmlTags };


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

식재료를 검색할 때 `Object`로 반환이 되는데

> 예시 : {ingredientId: 407, highlightedName: '바<em>나</em><em>나</em>', matchScore: 20.452925}

이걸 그대로 식재료 이름으로 추가하려했기 때문에 생긴 오류였습니다.
그래서 해당 데이터의 `highlightedName`을 가져오고, `<em>`태그를 제거하도록 하였습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).