### PR TITLE
[NPG-191] 기존 레시피 출처 표기 및 관리자화면 너비 고정

### DIFF
--- a/NangPaGo-admin/src/components/DashboardLayout.jsx
+++ b/NangPaGo-admin/src/components/DashboardLayout.jsx
@@ -35,49 +35,51 @@ export default function DashboardLayout({ children }) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <nav className="bg-white shadow-lg">
-        <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">Admin Dashboard</h1>
-            </div>
-            <div className="flex items-center">
-              <button
-                onClick={handleLogout}
-                className="ml-4 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              >
-                로그아웃
-              </button>
+    <div className="min-h-screen bg-gray-100 flex justify-center">
+      <div className="w-[1920px] min-h-screen bg-gray-100 flex flex-col">
+        <nav className="bg-white shadow-lg">
+          <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex justify-between h-16">
+              <div className="flex items-center">
+                <h1 className="text-2xl font-bold text-gray-900">Admin Dashboard</h1>
+              </div>
+              <div className="flex items-center">
+                <button
+                  onClick={handleLogout}
+                  className="ml-4 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                >
+                  로그아웃
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      </nav>
+        </nav>
 
-      <div className="flex h-[calc(100vh-4rem)]">
-        {/* 사이드바 */}
-        <div className="w-64 bg-white shadow-lg">
-          <div className="flex-1 flex flex-col">
-            <nav className="flex-1 px-2 py-4 space-y-1">
-              <NavLink to="/dashboard" icon={HomeIcon}>
-                Home
-              </NavLink>
-              <NavLink to="/dashboard/users" icon={UserGroupIcon}>
-                Users
-              </NavLink>
-              <NavLink to="/dashboard/security" icon={ShieldCheckIcon}>
-                Security
-              </NavLink>
-              <NavLink to="/dashboard/audit" icon={ClipboardDocumentListIcon}>
-                Audit
-              </NavLink>
-            </nav>
+        <div className="flex flex-1">
+          {/* 사이드바 */}
+          <div className="w-64 bg-white shadow-lg">
+            <div className="flex-1 flex flex-col">
+              <nav className="flex-1 px-2 py-4 space-y-1">
+                <NavLink to="/dashboard" icon={HomeIcon}>
+                  Home
+                </NavLink>
+                <NavLink to="/dashboard/users" icon={UserGroupIcon}>
+                  Users
+                </NavLink>
+                <NavLink to="/dashboard/security" icon={ShieldCheckIcon}>
+                  Security
+                </NavLink>
+                <NavLink to="/dashboard/audit" icon={ClipboardDocumentListIcon}>
+                  Audit
+                </NavLink>
+              </nav>
+            </div>
           </div>
-        </div>
 
-        {/* 메인 콘텐츠 */}
-        <div className="flex-1 overflow-auto">
-          {children}
+          {/* 메인 콘텐츠 */}
+          <div className="flex-1 overflow-auto">
+            {children}
+          </div>
         </div>
       </div>
     </div>

--- a/NangPaGo-client/src/components/recipe/Recipe.jsx
+++ b/NangPaGo-client/src/components/recipe/Recipe.jsx
@@ -33,7 +33,9 @@ function Recipe({ data: recipe }) {
 
   useEffect(() => {
     const adjustImageHeight = () => {
-      if (!rightSectionRef.current || !imageRef.current) return;
+      if (!rightSectionRef.current || !imageRef.current) {
+        return;
+      }
 
       if (window.innerWidth > 767) {
         const rightSectionHeight = rightSectionRef.current.offsetHeight;
@@ -101,21 +103,15 @@ function Recipe({ data: recipe }) {
             </div>
           </div>
 
-        <section className="mt-7 px-4">
-          <h2 className="text-lg font-semibold">요리 과정</h2>
-          <CookingStepsSlider
-            ref={sliderRef}
-            manuals={recipe.manuals}
-            manualImages={recipe.manualImages}
-          />
-          <div class="flex justify-end mt-14 sm:scroll-mt-20">
-            <span class="text-[7pt] sm:text-[8pt] text-gray-400">
-              * 이 레시피는 "
-              <a href="https://www.foodsafetykorea.go.kr/api/openApiInfo.do?menu_grp=MENU_GRP31&menu_no=661&show_cnt=10&start_idx=1&svc_no=COOKRCP01" target="_blank" class="text-blue-500 underline">
-                식품의약품안전처 - 요리 음식 레시피 DB
-              </a>
-              "에서 제공된 정보를 바탕으로 작성되었습니다.
-            </span>
+          <div className="mt-7 flex flex-col md:gap-4">
+            <IngredientList ingredients={recipe.ingredients} />
+            <NutritionInfo
+              calories={recipe.calorie}
+              fat={recipe.fat}
+              carbs={recipe.carbohydrate}
+              protein={recipe.protein}
+              sodium={recipe.natrium}
+            />
           </div>
         </div>
       </section>
@@ -127,6 +123,19 @@ function Recipe({ data: recipe }) {
           manuals={recipe.manuals}
           manualImages={recipe.manualImages}
         />
+        <div className="flex justify-end mt-14 sm:scroll-mt-20">
+          <span className="text-[7pt] sm:text-[8pt] text-gray-400">
+            * 이 레시피는 "
+            <a
+              href="https://www.foodsafetykorea.go.kr/api/openApiInfo.do?menu_grp=MENU_GRP31&menu_no=661&show_cnt=10&start_idx=1&svc_no=COOKRCP01"
+              target="_blank"
+              className="text-blue-500 underline"
+            >
+              식품의약품안전처 - 요리 음식 레시피 DB
+            </a>
+            "에서 제공된 정보를 바탕으로 작성되었습니다.
+          </span>
+        </div>
       </section>
       <LoginModal
         isOpen={showLoginModal}

--- a/NangPaGo-client/src/components/recipe/Recipe.jsx
+++ b/NangPaGo-client/src/components/recipe/Recipe.jsx
@@ -101,15 +101,21 @@ function Recipe({ data: recipe }) {
             </div>
           </div>
 
-          <div className="mt-7 flex flex-col md:gap-4">
-            <IngredientList ingredients={recipe.ingredients} />
-            <NutritionInfo
-              calories={recipe.calorie}
-              fat={recipe.fat}
-              carbs={recipe.carbohydrate}
-              protein={recipe.protein}
-              sodium={recipe.natrium}
-            />
+        <section className="mt-7 px-4">
+          <h2 className="text-lg font-semibold">요리 과정</h2>
+          <CookingStepsSlider
+            ref={sliderRef}
+            manuals={recipe.manuals}
+            manualImages={recipe.manualImages}
+          />
+          <div class="flex justify-end mt-14 sm:scroll-mt-20">
+            <span class="text-[7pt] sm:text-[8pt] text-gray-400">
+              * 이 레시피는 "
+              <a href="https://www.foodsafetykorea.go.kr/api/openApiInfo.do?menu_grp=MENU_GRP31&menu_no=661&show_cnt=10&start_idx=1&svc_no=COOKRCP01" target="_blank" class="text-blue-500 underline">
+                식품의약품안전처 - 요리 음식 레시피 DB
+              </a>
+              "에서 제공된 정보를 바탕으로 작성되었습니다.
+            </span>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## 개요
- 기존에 개발자가 넣어둔 레시피와 사용자가 직접 작성한 레시피를 구분하기 위해 출처를 표기함
<img width="334" alt="recipe_credit_source" src="https://github.com/user-attachments/assets/f4a3a083-620a-4bf8-b77d-e50a17a81adc" />


- 관리자 화면 너비 

기존에는 화면 비율을 50% 줄였을 때, 옆으로 늘어졌음
<img width="1280" alt="admin_기존_해상도비율" src="https://github.com/user-attachments/assets/cf59c407-a187-49c8-863c-95b4b109d037" />

50%로 줄였을 때도, 동일한 비율을 유지하도록 수정(=너비를 `w-[1920px]`로 고정)
<img width="1277" alt="admin_변경_해상도비율" src="https://github.com/user-attachments/assets/49f1fd3a-ffd9-43b9-a3ff-f36097ccf720" />


## PR 유형

- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).