### PR TITLE
[NO-ISSUE] 관리자 페이지 - Logout URI 수정

### DIFF
--- a/NangPaGo-admin/src/components/DashboardLayout.jsx
+++ b/NangPaGo-admin/src/components/DashboardLayout.jsx
@@ -26,7 +26,7 @@ export default function DashboardLayout({ children }) {
 
   const handleLogout = async () => {
     try {
-      const response = await axiosInstance.post('/logout');
+      const response = await axiosInstance.post('/api/logout');
       localStorage.setItem('isAuthenticated', 'false');
       navigate('/')
     } catch (error) {

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/config/SecurityConfig.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                 .successHandler(adminSuccessHandler)
             )
             .logout(logout -> logout
-                .logoutUrl("/logout")
+                .logoutUrl("/api/logout")
                 .logoutSuccessHandler(adminLogoutSuccessHandler)
             )
             .httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 관리자 페이지의 Logout URI 에 `/api` prefix가 없어, 요청에 실패(404)하는 문제를 해결합니다.

## PR 유형

- [x] 버그 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).