### PR TITLE
[NPG-184] 토큰 재발급 실패시 로그아웃 처리

### DIFF
--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/filter/JwtAuthenticationFilter.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/filter/JwtAuthenticationFilter.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mars.common.dto.ResponseDto;
 import com.mars.common.exception.NPGException;
 import com.mars.common.exception.NPGExceptionType;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/handler/AdminSuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/handler/AdminSuccessHandler.java
@@ -7,8 +7,8 @@ import com.mars.admin.auth.vo.UserDetailsImpl;
 import com.mars.admin.domain.auth.service.TokenService;
 import com.mars.admin.domain.user.repository.UserRepository;
 import com.mars.common.model.user.User;
+import com.mars.common.util.web.CookieUtil;
 import com.mars.common.util.web.JwtUtil;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -28,6 +28,7 @@ public class AdminSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private String clientHost;
 
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final TokenService tokenService;
 
     private final UserRepository userRepository;
@@ -44,24 +45,29 @@ public class AdminSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> NOT_FOUND_USER.of("사용자 검증 에러: " + email));
 
-        if(!user.getRole().equals("ROLE_ADMIN")){
+        if (!user.getRole().equals("ROLE_ADMIN")) {
             throw FORBIDDEN.of("해당 아이디로 접근할 수 없습니다.");
         }
 
         issueAccessAndRefreshTokens(response, user, email, authentication);
     }
 
-    private void issueAccessAndRefreshTokens(HttpServletResponse response, User user, String email, Authentication authentication) {
+    private void issueAccessAndRefreshTokens(HttpServletResponse response, User user, String email,
+        Authentication authentication) {
         Long userId = user.getId();
         String role = getRole(authentication);
 
-        String access = jwtUtil.createJwt("access", userId, email, role, jwtUtil.getAccessTokenExpireMillis());
-        String refresh = jwtUtil.createJwt("refresh", userId, email, role, jwtUtil.getRefreshTokenExpireMillis());
+        String access = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role,
+            jwtUtil.getAccessTokenExpireMillis());
+        String refresh = jwtUtil.createJwt(CookieUtil.REFRESH_TOKEN_NAME, userId, email, role,
+            jwtUtil.getRefreshTokenExpireMillis());
 
         tokenService.renewRefreshToken(email, refresh);
 
-        response.addCookie(createCookie("access", access, jwtUtil.getAccessTokenExpireMillis(), false));
-        response.addCookie(createCookie("refresh", refresh, jwtUtil.getRefreshTokenExpireMillis(), false));
+        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, access, jwtUtil.getAccessTokenExpireMillis(),
+            false);
+        cookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refresh, jwtUtil.getRefreshTokenExpireMillis(),
+            false);
     }
 
     private String getRole(Authentication authentication) {
@@ -70,14 +76,5 @@ public class AdminSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             .map(GrantedAuthority::getAuthority)
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("사용자 권한이 설정되지 않았습니다."));
-    }
-
-    private Cookie createCookie(String key, String value, long expireMillis, boolean httpOnly) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge((int) (expireMillis / 1000));
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(httpOnly);
-        return cookie;
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/handler/AdminSuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/handler/AdminSuccessHandler.java
@@ -7,7 +7,7 @@ import com.mars.admin.auth.vo.UserDetailsImpl;
 import com.mars.admin.domain.auth.service.TokenService;
 import com.mars.admin.domain.user.repository.UserRepository;
 import com.mars.common.model.user.User;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/service/AdminLogoutSuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/service/AdminLogoutSuccessHandler.java
@@ -1,7 +1,7 @@
 package com.mars.admin.auth.service;
 
 import com.mars.admin.domain.auth.repository.RefreshTokenRepository;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/service/AdminLogoutSuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/service/AdminLogoutSuccessHandler.java
@@ -1,14 +1,12 @@
 package com.mars.admin.auth.service;
 
 import com.mars.admin.domain.auth.repository.RefreshTokenRepository;
+import com.mars.common.exception.NPGExceptionType;
+import com.mars.common.util.web.CookieUtil;
 import com.mars.common.util.web.JwtUtil;
-import io.jsonwebtoken.ExpiredJwtException;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -21,20 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
 
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-        throws IOException, ServletException {
+        throws IOException {
 
-        try {
-            String refreshToken = extractRefreshToken(request);
-            handleLogout(refreshToken, response);
-        } catch (IllegalArgumentException e) {
-            response.setStatus(HttpStatus.BAD_REQUEST.value());
-            response.getWriter().write(e.getMessage());
-        }
+        String refreshToken = cookieUtil.findCookieByName(request, CookieUtil.REFRESH_TOKEN_NAME);
+        handleLogout(refreshToken, response);
     }
 
 
@@ -42,50 +36,26 @@ public class AdminLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
         validateRefreshToken(refreshToken);
 
         if (Boolean.FALSE.equals(refreshTokenRepository.existsByRefreshToken(refreshToken))) {
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            throw NPGExceptionType.UNAUTHORIZED_TOKEN_EXPIRED.of("유효하지 않은 Refresh Token입니다.");
         }
 
         String email = jwtUtil.getEmail(refreshToken);
         refreshTokenRepository.deleteByEmail(email);
 
-        invalidateCookie(response, "refresh");
-        invalidateCookie(response, "access");
+        cookieUtil.invalidateCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
+        cookieUtil.invalidateCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
 
         response.setStatus(HttpStatus.OK.value());
         response.getWriter().flush();
     }
 
     private void validateRefreshToken(String refreshToken) {
-        try {
-            if (Boolean.TRUE.equals(jwtUtil.isExpired(refreshToken))) {
-                throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
-            }
-
-            if (!"refresh".equals(jwtUtil.getCategory(refreshToken))) {
-                throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
-            }
-        } catch (ExpiredJwtException e) {
-            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
-        }
-    }
-
-    private String extractRefreshToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            throw new IllegalArgumentException("요청에 쿠키가 존재하지 않습니다.");
+        if (Boolean.TRUE.equals(jwtUtil.isExpired(refreshToken))) {
+            throw NPGExceptionType.UNAUTHORIZED_TOKEN_EXPIRED.of("Refresh Token이 만료되었습니다.");
         }
 
-        return Arrays.stream(cookies)
-            .filter(cookie -> "refresh".equals(cookie.getName()))
-            .map(Cookie::getValue)
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Refresh Token이 존재하지 않습니다."));
-    }
-
-    private void invalidateCookie(HttpServletResponse response, String cookieName) {
-        Cookie cookie = new Cookie(cookieName, null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        response.addCookie(cookie);
+        if (!CookieUtil.REFRESH_TOKEN_NAME.equals(jwtUtil.getCategory(refreshToken))) {
+            throw NPGExceptionType.UNAUTHORIZED_TOKEN_EXPIRED.of("유효하지 않은 Refresh Token입니다.");
+        }
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/config/SecurityConfig.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import com.mars.admin.auth.entrypoint.UnauthorizedEntryPoint;
 import com.mars.admin.auth.filter.JwtAuthenticationFilter;
 import com.mars.admin.auth.handler.AdminSuccessHandler;
 import com.mars.admin.auth.service.AdminLogoutSuccessHandler;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/auth/service/TokenService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/auth/service/TokenService.java
@@ -5,7 +5,7 @@ import static com.mars.common.exception.NPGExceptionType.UNAUTHORIZED_TOKEN_EXPI
 
 import com.mars.admin.domain.auth.repository.RefreshTokenRepository;
 import com.mars.common.dto.auth.RefreshTokenDto;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/auth/service/TokenService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/auth/service/TokenService.java
@@ -5,13 +5,12 @@ import static com.mars.common.exception.NPGExceptionType.UNAUTHORIZED_TOKEN_EXPI
 
 import com.mars.admin.domain.auth.repository.RefreshTokenRepository;
 import com.mars.common.dto.auth.RefreshTokenDto;
+import com.mars.common.util.web.CookieUtil;
 import com.mars.common.util.web.JwtUtil;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,15 +19,17 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = getRefreshTokenFromRequest(request);
+        String refreshToken = cookieUtil.findCookieByName(request, CookieUtil.REFRESH_TOKEN_NAME);
         validateRefreshToken(refreshToken);
 
         boolean isExist = refreshTokenRepository.existsByRefreshToken(refreshToken);
         if (!isExist) {
+            cookieUtil.invalidateCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
             throw BAD_REQUEST_INVALID.of("유효하지 않은 Refresh Token 입니다.");
         }
 
@@ -36,9 +37,10 @@ public class TokenService {
         String role = jwtUtil.getRole(refreshToken);
         Long userId = jwtUtil.getId(refreshToken);
 
-        String newAccessToken = jwtUtil.createJwt("access", userId, email, role, jwtUtil.getAccessTokenExpireMillis());
-
-        response.addCookie(createCookie("access", newAccessToken, jwtUtil.getAccessTokenExpireMillis()));
+        String newAccessToken = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role,
+            jwtUtil.getAccessTokenExpireMillis());
+        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, newAccessToken,
+            jwtUtil.getAccessTokenExpireMillis(), false);
     }
 
     @Transactional
@@ -46,18 +48,6 @@ public class TokenService {
         LocalDateTime expiration = LocalDateTime.now().plusNanos(jwtUtil.getRefreshTokenExpireMillis() * 1_000_000);
         refreshTokenRepository.deleteByEmail(email);
         refreshTokenRepository.save(new RefreshTokenDto(email, refreshToken, expiration).toEntity());
-    }
-
-    private String getRefreshTokenFromRequest(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            throw BAD_REQUEST_INVALID.of("요청에 쿠키가 존재하지 않습니다.");
-        }
-        return Arrays.stream(cookies)
-            .filter(cookie -> "refresh".equals(cookie.getName()))
-            .map(Cookie::getValue)
-            .findFirst()
-            .orElseThrow(() -> BAD_REQUEST_INVALID.of("Refresh Token이 존재하지 않습니다."));
     }
 
     private void validateRefreshToken(String refreshToken) {
@@ -68,14 +58,5 @@ public class TokenService {
         if (!"refresh".equals(jwtUtil.getCategory(refreshToken))) {
             throw BAD_REQUEST_INVALID.of("유효하지 않은 Refresh Token입니다.");
         }
-    }
-
-    private Cookie createCookie(String key, String value, long expireMillis) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge((int) (expireMillis / 1000));
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(false);
-        return cookie;
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/filter/JwtAuthenticationFilter.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/filter/JwtAuthenticationFilter.java
@@ -24,19 +24,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String path = request.getRequestURI();
-        return path.equals("/") ||
-            path.equals("/index.html") ||
-            path.matches("/static/.*") ||
-            path.matches("/assets/.*") ||
-            path.matches("/socialLogin/.*") ||
-            path.matches("/fonts/.*") ||
-            path.matches("/logo\\..*") ||
-            path.matches(".*\\.(js|css|ico|png|jpg|jpeg|gif|svg)$");
-    }
-
-    @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/filter/JwtAuthenticationFilter.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/filter/JwtAuthenticationFilter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mars.common.dto.ResponseDto;
 import com.mars.common.exception.NPGException;
 import com.mars.common.exception.NPGExceptionType;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
@@ -3,7 +3,7 @@ package com.mars.app.auth.handler;
 import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_USER;
 
 import com.mars.app.auth.vo.OAuth2UserImpl;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import com.mars.app.domain.auth.service.OAuth2ProviderTokenService;
 import com.mars.app.domain.auth.service.TokenService;
 import com.mars.common.model.user.User;

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
@@ -72,7 +72,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private void redirectToErrorPage(HttpServletResponse response, String existingProvider) throws IOException {
         String encodedTitle = URLEncoder.encode("이미 가입된 계정입니다.", StandardCharsets.UTF_8);
-        String encodedDescription = URLEncoder.encode("해당 이메일은 " + existingProvider + " 계정으로 이미 가입되어 있습니다.\n기존 계정으로 로그인하거나 다른 방법을 사용해 주세요.", StandardCharsets.UTF_8);
+        String encodedDescription = URLEncoder.encode(
+            "해당 이메일은 " + existingProvider + " 계정으로 이미 가입되어 있습니다.\n기존 계정으로 로그인하거나 다른 방법을 사용해 주세요.",
+            StandardCharsets.UTF_8);
         response.sendRedirect(clientHost + "/error?title=" + encodedTitle + "&description=" + encodedDescription);
     }
 
@@ -90,17 +92,22 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         return authorizedClient != null && authorizedClient.getRefreshToken() != null;
     }
 
-    private void issueAccessAndRefreshTokens(HttpServletResponse response, User user, String email, Authentication authentication) {
+    private void issueAccessAndRefreshTokens(HttpServletResponse response, User user, String email,
+        Authentication authentication) {
         Long userId = user.getId();
         String role = getRole(authentication);
 
-        String access = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role, jwtUtil.getAccessTokenExpireMillis());
-        String refresh = jwtUtil.createJwt(CookieUtil.REFRESH_TOKEN_NAME, userId, email, role, jwtUtil.getRefreshTokenExpireMillis());
+        String access = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role,
+            jwtUtil.getAccessTokenExpireMillis());
+        String refresh = jwtUtil.createJwt(CookieUtil.REFRESH_TOKEN_NAME, userId, email, role,
+            jwtUtil.getRefreshTokenExpireMillis());
 
         tokenService.renewRefreshToken(email, refresh);
 
-        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, access, jwtUtil.getAccessTokenExpireMillis(), false);
-        cookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refresh, jwtUtil.getRefreshTokenExpireMillis(), false);
+        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, access, jwtUtil.getAccessTokenExpireMillis(),
+            false);
+        cookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refresh, jwtUtil.getRefreshTokenExpireMillis(),
+            false);
     }
 
     private String getRole(Authentication authentication) {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
@@ -100,7 +100,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         tokenService.renewRefreshToken(email, refresh);
 
         cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, access, jwtUtil.getAccessTokenExpireMillis(), false);
-        cookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refresh, jwtUtil.getAccessTokenExpireMillis(), false);
+        cookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refresh, jwtUtil.getRefreshTokenExpireMillis(), false);
     }
 
     private String getRole(Authentication authentication) {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/handler/OAuth2SuccessHandler.java
@@ -3,12 +3,12 @@ package com.mars.app.auth.handler;
 import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_USER;
 
 import com.mars.app.auth.vo.OAuth2UserImpl;
+import com.mars.common.util.web.CookieUtil;
 import com.mars.common.util.web.JwtUtil;
 import com.mars.app.domain.auth.service.OAuth2ProviderTokenService;
 import com.mars.app.domain.auth.service.TokenService;
 import com.mars.common.model.user.User;
 import com.mars.app.domain.user.repository.UserRepository;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -36,6 +36,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private String clientHost;
 
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final TokenService tokenService;
     private final OAuth2ProviderTokenService oauth2ProviderTokenService;
     private final OAuth2AuthorizedClientManager OAuth2AuthorizedClientManager;
@@ -93,13 +94,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         Long userId = user.getId();
         String role = getRole(authentication);
 
-        String access = jwtUtil.createJwt("access", userId, email, role, jwtUtil.getAccessTokenExpireMillis());
-        String refresh = jwtUtil.createJwt("refresh", userId, email, role, jwtUtil.getRefreshTokenExpireMillis());
+        String access = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role, jwtUtil.getAccessTokenExpireMillis());
+        String refresh = jwtUtil.createJwt(CookieUtil.REFRESH_TOKEN_NAME, userId, email, role, jwtUtil.getRefreshTokenExpireMillis());
 
         tokenService.renewRefreshToken(email, refresh);
 
-        response.addCookie(createCookie("access", access, jwtUtil.getAccessTokenExpireMillis(), false));
-        response.addCookie(createCookie("refresh", refresh, jwtUtil.getRefreshTokenExpireMillis(), false));
+        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, access, jwtUtil.getAccessTokenExpireMillis(), false);
+        cookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refresh, jwtUtil.getAccessTokenExpireMillis(), false);
     }
 
     private String getRole(Authentication authentication) {
@@ -119,14 +120,5 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .principal(authentication)
                 .build()
         );
-    }
-
-    private Cookie createCookie(String key, String value, long expireMillis, boolean httpOnly) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge((int) (expireMillis / 1000));
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(httpOnly);
-        return cookie;
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/service/OAuth2LogoutService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/service/OAuth2LogoutService.java
@@ -1,11 +1,12 @@
 package com.mars.app.auth.service;
 
-import com.mars.common.util.JwtUtil;
+import com.mars.common.exception.NPGExceptionType;
+import com.mars.common.util.web.CookieUtil;
+import com.mars.common.util.web.JwtUtil;
 import com.mars.app.domain.auth.repository.RefreshTokenRepository;
-import io.jsonwebtoken.ExpiredJwtException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -16,42 +17,32 @@ public class OAuth2LogoutService {
 
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final CookieUtil cookieUtil;
 
     @Transactional
-    public void handleLogout(String refreshToken, HttpServletResponse response) {
+    public void handleLogout(String refreshToken, HttpServletResponse response) throws IOException {
         validateRefreshToken(refreshToken);
 
         if (Boolean.FALSE.equals(refreshTokenRepository.existsByRefreshToken(refreshToken))) {
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            throw NPGExceptionType.UNAUTHORIZED_TOKEN_EXPIRED.of("유효하지 않은 Refresh Token입니다.");
         }
 
         String email = jwtUtil.getEmail(refreshToken);
         refreshTokenRepository.deleteByEmail(email);
 
-        invalidateCookie(response, "refresh");
-        invalidateCookie(response, "access");
+        cookieUtil.invalidateCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
+        cookieUtil.invalidateCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
 
         response.setStatus(HttpStatus.OK.value());
     }
 
     private void validateRefreshToken(String refreshToken) {
-        try {
-            if (Boolean.TRUE.equals(jwtUtil.isExpired(refreshToken))) {
-                throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
-            }
-
-            if (!"refresh".equals(jwtUtil.getCategory(refreshToken))) {
-                throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
-            }
-        } catch (ExpiredJwtException e) {
-            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
+        if (Boolean.TRUE.equals(jwtUtil.isExpired(refreshToken))) {
+            throw NPGExceptionType.UNAUTHORIZED_TOKEN_EXPIRED.of("Refresh Token이 만료되었습니다.");
         }
-    }
 
-    private void invalidateCookie(HttpServletResponse response, String cookieName) {
-        Cookie cookie = new Cookie(cookieName, null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        response.addCookie(cookie);
+        if (!CookieUtil.REFRESH_TOKEN_NAME.equals(jwtUtil.getCategory(refreshToken))) {
+            throw NPGExceptionType.UNAUTHORIZED_TOKEN_EXPIRED.of("유효하지 않은 Refresh Token입니다.");
+        }
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/service/OAuth2LogoutService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/auth/service/OAuth2LogoutService.java
@@ -6,7 +6,6 @@ import com.mars.common.util.web.JwtUtil;
 import com.mars.app.domain.auth.repository.RefreshTokenRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,7 @@ public class OAuth2LogoutService {
     private final CookieUtil cookieUtil;
 
     @Transactional
-    public void handleLogout(String refreshToken, HttpServletResponse response) throws IOException {
+    public void handleLogout(String refreshToken, HttpServletResponse response) {
         validateRefreshToken(refreshToken);
 
         if (Boolean.FALSE.equals(refreshTokenRepository.existsByRefreshToken(refreshToken))) {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/security/SecurityConfig.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/security/SecurityConfig.java
@@ -7,7 +7,7 @@ import com.mars.app.auth.service.OAuth2LogoutService;
 import com.mars.app.auth.service.OAuth2UserService;
 import com.mars.app.auth.filter.JwtAuthenticationFilter;
 import com.mars.app.auth.vo.OAuth2RequestResolver;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/controller/AuthController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +36,7 @@ public class AuthController {
 
     @Operation(summary = "Access token 재발급")
     @PostMapping("/reissue")
-    public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) throws IOException {
         tokenService.reissueTokens(request, response);
         return ResponseEntity.ok().build();
     }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/service/TokenService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/service/TokenService.java
@@ -2,15 +2,16 @@ package com.mars.app.domain.auth.service;
 
 import com.mars.common.dto.auth.RefreshTokenDto;
 import com.mars.app.domain.auth.repository.RefreshTokenRepository;
-import com.mars.common.util.JwtUtil;
-import jakarta.servlet.http.Cookie;
+import com.mars.common.util.web.CookieUtil;
+import com.mars.common.util.web.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import static com.mars.common.exception.NPGExceptionType.*;
@@ -19,26 +20,31 @@ import static com.mars.common.exception.NPGExceptionType.*;
 @Service
 public class TokenService {
 
+    @Value("${client.host}")
+    private String clientHost;
+
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final CookieUtil cookieUtil;
 
     @Transactional
-    public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = getRefreshTokenFromRequest(request);
+    public void reissueTokens(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String refreshToken = cookieUtil.findCookieByName(request, CookieUtil.REFRESH_TOKEN_NAME);
         validateRefreshToken(refreshToken);
 
         boolean isExist = refreshTokenRepository.existsByRefreshToken(refreshToken);
         if (!isExist) {
-            throw BAD_REQUEST_INVALID.of("유효하지 않은 Refresh Token 입니다.");
+            cookieUtil.invalidateCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
+            cookieUtil.invalidateCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
+            throw UNAUTHORIZED_TOKEN_EXPIRED.of("유효하지 않은 Refresh Token 입니다.");
         }
 
         String email = jwtUtil.getEmail(refreshToken);
         String role = jwtUtil.getRole(refreshToken);
         Long userId = jwtUtil.getId(refreshToken);
 
-        String newAccessToken = jwtUtil.createJwt("access", userId, email, role, jwtUtil.getAccessTokenExpireMillis());
-
-        response.addCookie(createCookie("access", newAccessToken, jwtUtil.getAccessTokenExpireMillis()));
+        String newAccessToken = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role, jwtUtil.getAccessTokenExpireMillis());
+        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, newAccessToken, jwtUtil.getAccessTokenExpireMillis());
     }
 
     @Transactional
@@ -48,34 +54,13 @@ public class TokenService {
         refreshTokenRepository.save(new RefreshTokenDto(email, refreshToken, expiration).toEntity());
     }
 
-    private String getRefreshTokenFromRequest(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            throw BAD_REQUEST_INVALID.of("요청에 쿠키가 존재하지 않습니다.");
-        }
-        return Arrays.stream(cookies)
-            .filter(cookie -> "refresh".equals(cookie.getName()))
-            .map(Cookie::getValue)
-            .findFirst()
-            .orElseThrow(() -> BAD_REQUEST_INVALID.of("Refresh Token이 존재하지 않습니다."));
-    }
-
     private void validateRefreshToken(String refreshToken) {
         if (Boolean.TRUE.equals(jwtUtil.isExpired(refreshToken))) {
             throw UNAUTHORIZED_TOKEN_EXPIRED.of("Refresh Token이 만료되었습니다.");
         }
 
-        if (!"refresh".equals(jwtUtil.getCategory(refreshToken))) {
+        if (!CookieUtil.REFRESH_TOKEN_NAME.equals(jwtUtil.getCategory(refreshToken))) {
             throw BAD_REQUEST_INVALID.of("유효하지 않은 Refresh Token입니다.");
         }
-    }
-
-    private Cookie createCookie(String key, String value, long expireMillis) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge((int) (expireMillis / 1000));
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(false);
-        return cookie;
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/service/TokenService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/service/TokenService.java
@@ -24,8 +24,8 @@ public class TokenService {
     private String clientHost;
 
     private final JwtUtil jwtUtil;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final CookieUtil cookieUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public void reissueTokens(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -35,7 +35,6 @@ public class TokenService {
         boolean isExist = refreshTokenRepository.existsByRefreshToken(refreshToken);
         if (!isExist) {
             cookieUtil.invalidateCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
-            cookieUtil.invalidateCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
             throw UNAUTHORIZED_TOKEN_EXPIRED.of("유효하지 않은 Refresh Token 입니다.");
         }
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/service/TokenService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/service/TokenService.java
@@ -44,7 +44,7 @@ public class TokenService {
         Long userId = jwtUtil.getId(refreshToken);
 
         String newAccessToken = jwtUtil.createJwt(CookieUtil.ACCESS_TOKEN_NAME, userId, email, role, jwtUtil.getAccessTokenExpireMillis());
-        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, newAccessToken, jwtUtil.getAccessTokenExpireMillis());
+        cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, newAccessToken, jwtUtil.getAccessTokenExpireMillis(), false);
     }
 
     @Transactional

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/provider/TestJwtProvider.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/provider/TestJwtProvider.java
@@ -1,6 +1,6 @@
 package com.mars.app.provider;
 
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/support/IntegrationTestSupport.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/support/IntegrationTestSupport.java
@@ -1,7 +1,7 @@
 package com.mars.app.support;
 
 import com.google.firebase.FirebaseApp;
-import com.mars.common.util.JwtUtil;
+import com.mars.common.util.web.JwtUtil;
 import com.mars.app.provider.TestJwtProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/CookieUtil.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/CookieUtil.java
@@ -27,12 +27,12 @@ public class CookieUtil {
             .orElseThrow(() -> BAD_REQUEST_INVALID.of(name + "이 존재하지 않습니다."));
     }
 
-    public void addCookie(HttpServletResponse response, String key, String value, long expireMillis) {
+    public void addCookie(HttpServletResponse response, String key, String value, long expireMillis, boolean httpOnly) {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge((int) (expireMillis / 1000));
         cookie.setSecure(true);
         cookie.setPath("/");
-        cookie.setHttpOnly(false);
+        cookie.setHttpOnly(httpOnly);
         response.addCookie(cookie);
     }
 

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/CookieUtil.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/CookieUtil.java
@@ -1,0 +1,45 @@
+package com.mars.common.util.web;
+
+import static com.mars.common.exception.NPGExceptionType.BAD_REQUEST_INVALID;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public static final String ACCESS_TOKEN_NAME = "access";
+    public static final String REFRESH_TOKEN_NAME = "refresh";
+
+    public String findCookieByName(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw BAD_REQUEST_INVALID.of("요청에 쿠키가 존재하지 않습니다.");
+        }
+
+        return Arrays.stream(cookies)
+            .filter(cookie -> name.equals(cookie.getName()))
+            .map(Cookie::getValue)
+            .findFirst()
+            .orElseThrow(() -> BAD_REQUEST_INVALID.of(name + "이 존재하지 않습니다."));
+    }
+
+    public void addCookie(HttpServletResponse response, String key, String value, long expireMillis) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge((int) (expireMillis / 1000));
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(false);
+        response.addCookie(cookie);
+    }
+
+    public void invalidateCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+}

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/JwtUtil.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.mars.common.util;
+package com.mars.common.util.web;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/NangPaGo-client/src/api/axiosInstance.js
+++ b/NangPaGo-client/src/api/axiosInstance.js
@@ -1,21 +1,40 @@
 import axios from 'axios';
+import { ERROR_ROUTES } from '../common/constants/routes';
+
+let store = null;
+let logoutAction = null;
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+export const initializeStore = (reduxStore, logout) => {
+  store = reduxStore;
+  logoutAction = logout;
+};
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_HOST,
   withCredentials: true,
 });
 
-let isRefreshing = false;
-let refreshSubscribers = [];
-
 const hasRefreshToken = () => {
   return document.cookie.split('; ').some((row) => row.startsWith('refresh'));
+};
+
+const dispatchLogout = () => {
+  if (store && logoutAction) {
+    store.dispatch(logoutAction());
+  }
 };
 
 // 토큰 재발급이 완료된 후 기존 요청들을 재시도
 const onRefreshed = () => {
   refreshSubscribers.forEach((callback) => callback());
   refreshSubscribers = [];
+};
+
+const removeAccessAndRefreshFromCookie = () => {
+  document.cookie = 'refresh=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+  document.cookie = 'access=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
 };
 
 // 토큰 재발급 실패 시 대기 중인 요청들을 reject
@@ -50,41 +69,46 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    if (
-      error.response?.status === 401 &&
-      !originalRequest._retry &&
-      hasRefreshToken()
-    ) {
-      originalRequest._retry = true;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (!hasRefreshToken()) {
+        // 브라우저 쿠키에 토큰이 없다면 홈으로
+        window.location.href = '/';
+      } else {
+        // 액세스 토큰 재발급
+        originalRequest._retry = true;
+        if (!isRefreshing) {
+          isRefreshing = true;
 
-      if (!isRefreshing) {
-        isRefreshing = true;
+          try {
+            await axiosInstance.post('/api/auth/reissue');
+            isRefreshing = false;
+            onRefreshed();
+            return axiosInstance(originalRequest);
+          } catch (refreshError) {
+            isRefreshing = false;
+            onRefreshError(refreshError);
+            if (refreshError.response?.status === 401) {
+              dispatchLogout();
+              removeAccessAndRefreshFromCookie();
 
-        try {
-          await axiosInstance.post('/api/auth/reissue');
-          isRefreshing = false;
-          onRefreshed();
-          return axiosInstance(originalRequest);
-        } catch (refreshError) {
-          isRefreshing = false;
-          onRefreshError(refreshError);
-          if (refreshError.response?.status === 401) {
-            window.location.href = '/login/expired';
+              if (!ERROR_ROUTES.includes(window.location.pathname)) {
+                window.location.href = ERROR_ROUTES.LOGIN_EXPIRED;
+              }
+            }
+            return Promise.reject(refreshError);
           }
-          return Promise.reject(refreshError);
         }
-      }
 
-      // 토큰 재발급 진행 중일 때의 요청들은 대기열에 추가
-      return new Promise((resolve, reject) => {
-        refreshSubscribers.push((error) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve(axiosInstance(originalRequest));
-          }
+        return new Promise((resolve, reject) => {
+          refreshSubscribers.push((error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(axiosInstance(originalRequest));
+            }
+          });
         });
-      });
+      }
     }
     return Promise.reject(error);
   },

--- a/NangPaGo-client/src/api/axiosInstance.js
+++ b/NangPaGo-client/src/api/axiosInstance.js
@@ -68,7 +68,9 @@ axiosInstance.interceptors.response.use(
         } catch (refreshError) {
           isRefreshing = false;
           onRefreshError(refreshError);
-          console.error('토큰 갱신 실패:', refreshError);
+          if (refreshError.response?.status === 401) {
+            window.location.href = '/login/expired';
+          }
           return Promise.reject(refreshError);
         }
       }

--- a/NangPaGo-client/src/common/constants/routes.js
+++ b/NangPaGo-client/src/common/constants/routes.js
@@ -1,0 +1,17 @@
+export const ERROR_ROUTES = Object.freeze({
+  UNAUTHENTICATED: '/unauthenticated',
+  LOGIN_EXPIRED: '/login/expired',
+  ERROR: '/error',
+});
+
+export const redirectToLoginExpired = () => {
+  const errorPaths = Object.values(ERROR_ROUTES);
+  if (!errorPaths.includes(window.location.pathname)) {
+    window.location.href = ERROR_ROUTES.LOGIN_EXPIRED;
+  }
+};
+
+export const AUTH_ROUTES = Object.freeze({
+  LOGIN: '/login',
+  LOGOUT: '/logout',
+});

--- a/NangPaGo-client/src/components/page/ErrorGuidePage.jsx
+++ b/NangPaGo-client/src/components/page/ErrorGuidePage.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+
+// eslint-disable-next-line react/prop-types
+function ErrorGuidePage({ title, message, showLoginButton = true }) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-8 rounded-lg relative flex flex-col items-center max-w-[300px] w-[calc(100%-32px)]">
+        <p className="text-center text-lg font-semibold text-gray-600 mb-2">
+          {title}
+        </p>
+        <p className="text-center text-sm text-gray-500 whitespace-pre-line">
+          {message}
+        </p>
+        <div className="flex gap-2 mt-4">
+          <Link to="/" className="bg-gray-400 text-white px-5 py-3 rounded-lg">
+            홈으로
+          </Link>
+          {showLoginButton && (
+            <Link
+              to="/login"
+              className="bg-primary text-white px-5 py-3 rounded-lg"
+            >
+              로그인
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ErrorGuidePage;

--- a/NangPaGo-client/src/main.jsx
+++ b/NangPaGo-client/src/main.jsx
@@ -4,6 +4,11 @@ import './globals.css';
 import App from './App.jsx';
 import { Provider } from 'react-redux';
 import store from './store';
+import { initializeStore } from './api/axiosInstance';
+import { logout } from './slices/loginSlice';
+
+// store 초기화
+initializeStore(store, logout);
 
 const root = document.getElementById('root');
 

--- a/NangPaGo-client/src/pages/error/LoginExpired.jsx
+++ b/NangPaGo-client/src/pages/error/LoginExpired.jsx
@@ -1,0 +1,15 @@
+import ErrorGuidePage from '../../components/page/ErrorGuidePage.jsx';
+
+function LoginExpired() {
+  const message = `일정 기간 동안 활동이 없어
+자동 로그아웃되었습니다.
+
+안전한 서비스 이용을 위해
+다시 로그인해 주세요.`;
+
+  return (
+    <ErrorGuidePage title="로그인 정보가 만료되었습니다." message={message} />
+  );
+}
+
+export default LoginExpired;

--- a/NangPaGo-client/src/pages/error/NotFound.jsx
+++ b/NangPaGo-client/src/pages/error/NotFound.jsx
@@ -1,24 +1,12 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import ErrorGuidePage from '../../components/page/ErrorGuidePage.jsx';
 
 function NotFound() {
+  const message = `
+요청하신 페이지가 존재하지 않거나,
+주소를 잘못 입력하였습니다.`;
+
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-      <div className="bg-white p-8 rounded-lg relative flex flex-col items-center max-w-[300px] w-[calc(100%-32px)]">
-        <p className="text-center text-base font-semibold text-gray-600 mb-2">
-          404 - 페이지를 찾을 수 없습니다
-        </p>
-        <p className="text-center text-sm text-gray-500">
-          요청하신 페이지가 존재하지 않거나,<br />주소를 잘못 입력하셨습니다.
-        </p>
-        <Link
-          to="/"
-          className="mt-4 bg-primary text-white px-5 py-3 rounded-lg"
-        >
-          홈으로 이동
-        </Link>
-      </div>
-    </div>
+    <ErrorGuidePage title="페이지를 찾을 수 없습니다." message={message} showLoginButton={false}/>
   );
 }
 

--- a/NangPaGo-client/src/pages/error/UnauthenticatedAccess.jsx
+++ b/NangPaGo-client/src/pages/error/UnauthenticatedAccess.jsx
@@ -1,25 +1,12 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import ErrorGuidePage from '../../components/page/ErrorGuidePage.jsx';
 
 function UnauthenticatedAccess() {
-  return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-      <div className="bg-white p-8 rounded-lg relative flex flex-col items-center max-w-[300px] w-[calc(100%-32px)]">
-        <p className="text-center text-lg font-semibold text-gray-600 mb-2">
-          로그인 후 이용해주세요
-        </p>
-        <p className="text-center text-sm text-gray-500">
-          이 페이지에 접근하려면<br />로그인이 필요합니다.<br />로그인 후 다시 시도해주세요.
-        </p>
-        <Link
-          to="/login"
-          className="mt-4 bg-primary text-white px-5 py-3 rounded-lg"
-        >
-          로그인 페이지로 이동
-        </Link>
-      </div>
-    </div>
-  );
+  const message = `이 페이지에 접근하려면
+로그인이 필요합니다.
+
+로그인 후 다시 시도해주세요.`;
+
+  return <ErrorGuidePage title="로그인 후 이용해주세요" message={message} />;
 }
 
 export default UnauthenticatedAccess;

--- a/NangPaGo-client/src/routes/Router.jsx
+++ b/NangPaGo-client/src/routes/Router.jsx
@@ -13,6 +13,7 @@ import Error from '../pages/error/Error.jsx';
 import AuthenticatedRoute from './AuthenticatedRoute';
 import UnauthenticatedAccess from '../pages/error/UnauthenticatedAccess';
 import NotFound from '../pages/error/NotFound';
+import LoginExpired from '../pages/error/LoginExpired.jsx';
 
 const router = createBrowserRouter([
   {
@@ -89,6 +90,10 @@ const router = createBrowserRouter([
   {
     path: '/unauthenticated',
     element: <UnauthenticatedAccess />,
+  },
+  {
+    path: '/login/expired',
+    element: <LoginExpired />,
   },
   {
     path: '*',


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 리프레시 토큰 만료 등 reissue 요청 실패 시 클라이언트 상태를 로그아웃 상태로 처리하도록 개선합니다.

<img width="393" alt="image" src="https://github.com/user-attachments/assets/d0954e80-3b5b-4ba7-85f2-9027fa9adceb" />

- 로그인&로그아웃 관련 쿠키 처리에 관한 중복 코드를 `common` 으로 분리합니다.
- 클라이언트 에러 페이지를 공통 컴포넌트로 분리합니다.


## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).