### PR TITLE
[NPG-210] 유저 조회 - `findById()`로 조회할 수 있게 개선

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/component/auth/AuthenticationHolder.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/component/auth/AuthenticationHolder.java
@@ -1,5 +1,6 @@
 package com.mars.app.component.auth;
 
+import com.mars.common.auth.UserDetailsImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,9 +12,17 @@ public class AuthenticationHolder {
 
     public static String getCurrentUserEmail() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.getPrincipal() instanceof UserDetails userDetails) {
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
             return userDetails.getUsername();
         }
         return "anonymous_user";
+    }
+
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
+            return userDetails.getId();
+        }
+        return null;
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/community/controller/CommunityCommentController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/community/controller/CommunityCommentController.java
@@ -35,9 +35,8 @@ public class CommunityCommentController {
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "5") int pageSize) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-
-        return ResponseDto.of(communityCommentService.pagedCommentsByCommunity(id, email, pageNo, pageSize));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityCommentService.pagedCommentsByCommunity(id, userId, pageNo, pageSize));
     }
 
     @Operation(summary = "댓글 작성")
@@ -47,8 +46,8 @@ public class CommunityCommentController {
         @RequestBody CommunityCommentRequestDto requestDto,
         @PathVariable("id") Long id) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityCommentService.create(requestDto, email, id), "댓글이 성공적으로 추가되었습니다.");
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityCommentService.create(requestDto, userId, id), "댓글이 성공적으로 추가되었습니다.");
     }
 
     @Operation(summary = "댓글 수정")
@@ -59,8 +58,8 @@ public class CommunityCommentController {
         @PathVariable("commentId") Long commentId,
         @PathVariable String id) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityCommentService.update(commentId, email, requestDto), "댓글이 성공적으로 수정되었습니다.");
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityCommentService.update(commentId, userId, requestDto), "댓글이 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "댓글 삭제")
@@ -70,8 +69,8 @@ public class CommunityCommentController {
         @PathVariable("commentId") Long commentId,
         @PathVariable String id) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        communityCommentService.delete(commentId, email);
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        communityCommentService.delete(commentId, userId);
         return ResponseDto.of(null, "댓글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/community/dto/CommunityCommentResponseDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/community/dto/CommunityCommentResponseDto.java
@@ -14,13 +14,13 @@ public record CommunityCommentResponseDto(
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
-    public static CommunityCommentResponseDto of(CommunityComment communityComment, String email) {
+    public static CommunityCommentResponseDto of(CommunityComment communityComment, Long userId) {
         return CommunityCommentResponseDto.builder()
             .id(communityComment.getId())
             .postId(communityComment.getCommunity().getId())
             .content(communityComment.getContent())
             .email(maskEmail(communityComment.getUser().getEmail()))
-            .isOwnedByUser(communityComment.getUser().getEmail().equals(email))
+            .isOwnedByUser(communityComment.getUser().getId().equals(userId))
             .createdAt(communityComment.getCreatedAt())
             .updatedAt(communityComment.getUpdatedAt())
             .build();

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/community/service/CommunityCommentService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/community/service/CommunityCommentService.java
@@ -31,57 +31,55 @@ public class CommunityCommentService {
     private final UserRepository userRepository;
 
     public PageDto<CommunityCommentResponseDto> pagedCommentsByCommunity(Long communityId,
-        String email,
+        Long userId,
         int pageNo,
         int pageSize) {
+
         validateCommunity(communityId);
         return PageDto.of(
             communityCommentRepository.findByCommunityId(communityId, createPageRequest(pageNo, pageSize))
-                .map(comment -> CommunityCommentResponseDto.of(comment, email))
+                .map(comment -> CommunityCommentResponseDto.of(comment, userId))
         );
     }
 
     @Transactional
-    public CommunityCommentResponseDto create(CommunityCommentRequestDto requestDto, String email, Long communityId) {
-        User user = findUserByEmail(email);
+    public CommunityCommentResponseDto create(CommunityCommentRequestDto requestDto, Long userId, Long communityId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(NOT_FOUND_USER::of);
+
         return CommunityCommentResponseDto.of(communityCommentRepository.save(
-            CommunityComment.create(validateCommunity(communityId), user, requestDto.content())), user.getEmail());
+            CommunityComment.create(validateCommunity(communityId), user, requestDto.content())), user.getId());
     }
 
     @Transactional
-    public CommunityCommentResponseDto update(Long commentId, String email, CommunityCommentRequestDto requestDto) {
+    public CommunityCommentResponseDto update(Long commentId, Long userId, CommunityCommentRequestDto requestDto) {
         CommunityComment comment = validateComment(commentId);
-        validateOwnership(comment, email);
+        validateOwnership(comment, userId);
         comment.updateText(requestDto.content());
-        return CommunityCommentResponseDto.of(comment, email);
+        return CommunityCommentResponseDto.of(comment, userId);
     }
 
     @Transactional
-    public void delete(Long commentId, String email) {
+    public void delete(Long commentId, Long userId) {
         CommunityComment comment = validateComment(commentId);
-        validateOwnership(comment, email);
+        validateOwnership(comment, userId);
         communityCommentRepository.delete(comment);
     }
 
-    private void validateOwnership(CommunityComment comment, String email) {
-        if (!comment.getUser().getEmail().equals(email)) {
+    private void validateOwnership(CommunityComment comment, Long userId) {
+        if (!comment.getUser().getId().equals(userId)) {
             throw UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT.of("댓글을 수정/삭제할 권한이 없습니다.");
         }
     }
 
     private Community validateCommunity(Long communityId) {
         return communityRepository.findById(communityId)
-            .orElseThrow(() -> NOT_FOUND_COMMUNITY.of());
-    }
-
-    private User findUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-            .orElseThrow(() -> NOT_FOUND_USER.of());
+            .orElseThrow(NOT_FOUND_COMMUNITY::of);
     }
 
     private CommunityComment validateComment(Long commentId) {
         return communityCommentRepository.findById(commentId)
-            .orElseThrow(() -> NOT_FOUND_COMMUNITY_COMMENT.of());
+            .orElseThrow(NOT_FOUND_COMMUNITY_COMMENT::of);
     }
 
     private PageRequest createPageRequest(int pageNo, int pageSize) {

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/community/service/CommunityCommentServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/community/service/CommunityCommentServiceTest.java
@@ -1,0 +1,175 @@
+package com.mars.app.domain.comment.community.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.mars.app.domain.comment.community.dto.CommunityCommentRequestDto;
+import com.mars.app.domain.comment.community.dto.CommunityCommentResponseDto;
+import com.mars.app.domain.comment.community.repository.CommunityCommentRepository;
+import com.mars.app.domain.community.repository.CommunityRepository;
+import com.mars.app.domain.user.repository.UserRepository;
+import com.mars.app.support.IntegrationTestSupport;
+import com.mars.common.dto.PageDto;
+import com.mars.common.exception.NPGException;
+import com.mars.common.model.comment.community.CommunityComment;
+import com.mars.common.model.community.Community;
+import com.mars.common.model.user.User;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CommunityCommentServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CommunityCommentRepository communityCommentRepository;
+    @Autowired
+    private CommunityRepository communityRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CommunityCommentService communityCommentService;
+
+    @AfterEach
+    void tearDown() {
+        communityCommentRepository.deleteAllInBatch();
+        communityRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("게시글의 모든 댓글을 조회할 수 있다.")
+    @Test
+    void pagedCommentsByCommunity() {
+        // given
+        int pageNo = 0;
+        int pageSize = 3;
+
+        User user = createUser("dummy@nangpago.com");
+        Community community = createCommunity(user);
+        List<CommunityComment> comments = Arrays.asList(
+            createCommunityComment(community, user, "1번째 댓글"),
+            createCommunityComment(community, user, "2번째 댓글"),
+            createCommunityComment(community, user, "3번째 댓글"),
+            createCommunityComment(community, user, "4번째 댓글")
+        );
+
+        userRepository.save(user);
+        communityRepository.save(community);
+        communityCommentRepository.saveAll(comments);
+
+        // when
+        PageDto<CommunityCommentResponseDto> pageDto = communityCommentService.pagedCommentsByCommunity(
+            community.getId(), user.getId(), pageNo, pageSize);
+
+        // then
+        assertThat(pageDto)
+            .extracting(PageDto::getTotalPages, PageDto::getTotalItems)
+            .containsExactly(2, 4L);
+    }
+
+    @DisplayName("게시글에 댓글을 작성할 수 있다.")
+    @Test
+    void create() {
+        // given
+        User user = createUser("dummy@nangpago.com");
+        Community community = createCommunity(user);
+
+        userRepository.save(user);
+        communityRepository.save(community);
+
+        CommunityCommentRequestDto requestDto = new CommunityCommentRequestDto("댓글 작성 예시");
+
+        // when
+        CommunityCommentResponseDto responseDto = communityCommentService.create(requestDto, user.getId(), community.getId());
+
+        // then
+        assertThat(responseDto)
+            .extracting("content", "isOwnedByUser")
+            .containsExactly("댓글 작성 예시", true);
+    }
+
+    @DisplayName("게시글의 댓글을 수정할 수 있다.")
+    @Test
+    void update() {
+        // given
+        User user = createUser("dummy@nangpago.com");
+        Community community = createCommunity(user);
+        CommunityComment comment = createCommunityComment(community, user, "변경 전 댓글입니다.");
+
+        userRepository.save(user);
+        communityRepository.save(community);
+        communityCommentRepository.save(comment);
+
+        String updateText = "변경된 댓글입니다.";
+        CommunityCommentRequestDto requestDto = new CommunityCommentRequestDto(updateText);
+
+        // when
+        CommunityCommentResponseDto responseDto = communityCommentService.update(comment.getId(), user.getId(), requestDto);
+
+        // then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto).extracting("content").isEqualTo(updateText);
+    }
+
+    @DisplayName("게시글의 댓글을 삭제할 수 있다.")
+    @Test
+    void delete() {
+        // given
+        User user = createUser("dummy@nangpago.com");
+        Community community = createCommunity(user);
+        CommunityComment comment = createCommunityComment(community, user, "댓글");
+
+        userRepository.save(user);
+        communityRepository.save(community);
+        communityCommentRepository.save(comment);
+
+        // when
+        communityCommentService.delete(comment.getId(), user.getId());
+
+        // then
+        assertThat(communityCommentRepository.existsById(comment.getId()))
+            .isFalse();
+    }
+
+    @DisplayName("다른 유저의 댓글을 수정/삭제 시도할 때 예외를 발생시킬 수 있다.")
+    @Test
+    void validateOwnershipException() {
+        // given
+        User user = createUser("dummy@nangpago.com");
+        Community community = createCommunity(user);
+        CommunityComment comment = createCommunityComment(community, user, "댓글");
+
+        userRepository.save(user);
+        communityRepository.save(community);
+        communityCommentRepository.save(comment);
+
+        Long anotherUserId = 999L;
+
+        // when, then
+        assertThatThrownBy(() -> communityCommentService.delete(comment.getId(), anotherUserId))
+            .isInstanceOf(NPGException.class)
+            .hasMessage("댓글을 수정/삭제할 권한이 없습니다.");
+    }
+
+    private User createUser(String email) {
+        return User.builder()
+            .email(email)
+            .build();
+    }
+
+    private Community createCommunity(User user) {
+        return Community.builder()
+            .user(user)
+            .title("Test Community")
+            .content("Test Content")
+            .isPublic(true)
+            .build();
+    }
+
+    private CommunityComment createCommunityComment(Community community, User user, String comment) {
+        return CommunityComment.create(community, user, comment);
+    }
+}

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/auth/UserDetailsImpl.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/auth/UserDetailsImpl.java
@@ -1,0 +1,37 @@
+package com.mars.common.auth;
+
+import java.util.Collection;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final Long id;
+    private final String email;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    @Builder
+    private UserDetailsImpl(Long id, String email, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.authorities = authorities;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/JwtUtil.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/util/web/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.mars.common.util.web;
 
+import com.mars.common.auth.UserDetailsImpl;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -108,7 +109,11 @@ public class JwtUtil {
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
         
-        UserDetails principal = new User(claims.get("email").toString(), "", authorities);
+        UserDetailsImpl principal = UserDetailsImpl.builder()
+            .id(claims.get("id", Long.class))
+            .email(claims.get("email").toString())
+            .authorities(authorities)
+            .build();
         
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- AS-IS
  - User 엔티티를 조회할 때 `findByEmail()` 로 조회.
    - 인덱스가 걸려있지 않고, email string 값으로 조회하고 있으므로 조회 성능 하락 요인
- TO-BE
  - `findById()` 로 조회
  - 엑세스 토큰 클레임에 User.id 를 추가했으므로 구현이 가능해졌음.
    - 관련 PR: https://github.com/MARS-LIKELION/NangPaGo/pull/206
- 테스트 및 예제 차원으로 CommunityComment 관련 API에 우선 적용함.
  - 나머지 API도 모두 적용해야 함

## PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).