### PR TITLE
[NO-ISSUE] Fix: CookingStepsSlider의 ForwardRef 경고 해결

### DIFF
--- a/NangPaGo-client/src/components/recipe/CookingStepsSlider.jsx
+++ b/NangPaGo-client/src/components/recipe/CookingStepsSlider.jsx
@@ -1,8 +1,8 @@
 import Slider from 'react-slick';
 import CookingSteps from './CookingSteps';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, forwardRef } from 'react';
 
-function CookingStepsSlider({ manuals, manualImages }) {
+const CookingStepsSlider = forwardRef(({ manuals, manualImages }, ref) => {
   const sliderSettings = {
     dots: true,
     infinite: false,
@@ -14,6 +14,12 @@ function CookingStepsSlider({ manuals, manualImages }) {
   const [sliderKey, setSliderKey] = useState(0);
   const [currentSlide, setCurrentSlide] = useState(0);
   const sliderRef = useRef(null);
+
+  useEffect(() => {
+    if (ref && ref.current !== sliderRef.current) {
+      ref.current = sliderRef.current;
+    }
+  }, []);
 
   useEffect(() => {
     const handleResize = () => {
@@ -54,6 +60,6 @@ function CookingStepsSlider({ manuals, manualImages }) {
       </div>
     </div>
   );
-}
+});
 
 export default CookingStepsSlider;


### PR DESCRIPTION
## 개요
### Fix: CookingStepsSlider의 ForwardRef 경고 해결
- 레시피 상세 페이지에서 발생한 ForwardRef 경고가 발생함
- 부모 컴포넌트에서 자식 컴포넌트의 DOM 요소에 접근하기 위해 forwardRef를 사용하도록 수정
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/c55859c6-c0fe-49bf-af8c-7d751f1bea70" />


## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).