### PR TITLE
[NPG-190] 레시피 요리과정 슬라이더 버튼 추가

### DIFF
--- a/NangPaGo-client/src/components/recipe/CookingStepsSlider.jsx
+++ b/NangPaGo-client/src/components/recipe/CookingStepsSlider.jsx
@@ -11,9 +11,9 @@ function ArrowButton({ onClick, direction }) {
       onClick={onClick}
       className={`absolute top-1/2 transform -translate-y-1/2 z-10
         ${direction === 'left' ? 'left-2' : 'right-2'}
-        bg-white/20 w-9 h-9 rounded-full shadow-md
+        bg-white/20 w-11 h-11 rounded-full shadow-md
         hover:bg-white/60 transition-colors
-        text-gray-600 text-xl flex items-center justify-center`}
+        text-gray-600 text-2xl flex items-center justify-center`}
     >
       {direction === 'left' ? <FaChevronLeft /> : <FaChevronRight />}
     </button>

--- a/NangPaGo-client/src/components/recipe/CookingStepsSlider.jsx
+++ b/NangPaGo-client/src/components/recipe/CookingStepsSlider.jsx
@@ -1,16 +1,26 @@
 import Slider from 'react-slick';
 import CookingSteps from './CookingSteps';
 import { useEffect, useState, useRef, forwardRef } from 'react';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
+function ArrowButton({ onClick, direction }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`absolute top-1/2 transform -translate-y-1/2 z-10
+        ${direction === 'left' ? 'left-2' : 'right-2'}
+        bg-white/20 w-9 h-9 rounded-full shadow-md
+        hover:bg-white/60 transition-colors
+        text-gray-600 text-xl flex items-center justify-center`}
+    >
+      {direction === 'left' ? <FaChevronLeft /> : <FaChevronRight />}
+    </button>
+  );
+}
 
 const CookingStepsSlider = forwardRef(({ manuals, manualImages }, ref) => {
-  const sliderSettings = {
-    dots: true,
-    infinite: false,
-    slidesToShow: 1,
-    slidesToScroll: 1,
-    beforeChange: (current, next) => setCurrentSlide(next),
-  };
-
   const [sliderKey, setSliderKey] = useState(0);
   const [currentSlide, setCurrentSlide] = useState(0);
   const sliderRef = useRef(null);
@@ -19,36 +29,33 @@ const CookingStepsSlider = forwardRef(({ manuals, manualImages }, ref) => {
     if (ref && ref.current !== sliderRef.current) {
       ref.current = sliderRef.current;
     }
-  }, []);
+  }, [ref]);
 
   useEffect(() => {
-    const handleResize = () => {
-      setSliderKey((prevKey) => prevKey + 1);
-    };
-
+    const handleResize = () => setSliderKey((prevKey) => prevKey + 1);
     window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   useEffect(() => {
-    if (sliderRef.current && sliderRef.current.slickGoTo) {
+    if (sliderRef.current?.slickGoTo) {
       sliderRef.current.slickGoTo(currentSlide);
     }
   }, [sliderKey, currentSlide]);
 
+  const sliderSettings = {
+    dots: true,
+    infinite: false,
+    draggable: false,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    beforeChange: (_, next) => setCurrentSlide(next),
+    prevArrow: <ArrowButton direction="left" />,
+    nextArrow: <ArrowButton direction="right" />,
+  };
+
   return (
     <div>
-      <div className="block md:hidden">
-        {manuals.map((step, index) => (
-          <div key={index} className="mt-4">
-            <CookingSteps steps={[step]} stepImages={[manualImages[index]]} />
-          </div>
-        ))}
-      </div>
-
       <div className="hidden md:block">
         <Slider {...sliderSettings} key={sliderKey} ref={sliderRef}>
           {manuals.map((step, index) => (


### PR DESCRIPTION
## 개요
- 개선 전: md와 lg일때, 다음 요리과정을 보려면, 마우스로 드래그해서 잡아끌어야 했음.
- 개선 후: 이전 단계, 다음 단계로 넘어가는 버튼 추가 및 드래그 비활성화(`draggable: false`)
<img width="599" alt="KakaoTalk_20250128_220231585" src="https://github.com/user-attachments/assets/a6c2b0f9-0176-40ec-8b4e-ee86aab89b99" />


## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).