### PR TITLE
[NPG-210] `findById` 리팩터링 - NPE 방지 및 일부 코드에 적용

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/aop/auth/AuthenticationAspect.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/aop/auth/AuthenticationAspect.java
@@ -3,6 +3,7 @@ package com.mars.app.aop.auth;
 import com.mars.common.exception.NPGExceptionType;
 import com.mars.app.component.auth.AuthenticationHolder;
 import com.mars.app.domain.user.repository.UserRepository;
+import com.mars.common.model.user.User;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -17,13 +18,13 @@ public class AuthenticationAspect {
     private final UserRepository userRepository;
 
     @Around("@annotation(com.mars.app.aop.auth.AuthenticatedUser)")
-    public Object validateAndGetUserEmail(ProceedingJoinPoint joinPoint) throws Throwable {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        if (email == null || "anonymous_user".equals(email)) {
+    public Object validateUserById(ProceedingJoinPoint joinPoint) throws Throwable {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        if (userId.equals(User.ANONYMOUS_USER_ID)) {
             throw NPGExceptionType.UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT.of();
         }
 
-        if (Boolean.FALSE.equals(userRepository.existsByEmail(email))) {
+        if (Boolean.FALSE.equals(userRepository.existsById(userId))) {
             throw NPGExceptionType.NOT_FOUND_USER.of();
         }
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/component/auth/AuthenticationHolder.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/component/auth/AuthenticationHolder.java
@@ -1,9 +1,9 @@
 package com.mars.app.component.auth;
 
 import com.mars.common.auth.UserDetailsImpl;
+import com.mars.common.model.user.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,6 +23,6 @@ public class AuthenticationHolder {
         if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
             return userDetails.getId();
         }
-        return null;
+        return User.ANONYMOUS_USER_ID;
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/controller/AuthController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/auth/controller/AuthController.java
@@ -29,8 +29,8 @@ public class AuthController {
     @Operation(summary = "Email, Role 정보 조회")
     @GetMapping("/status")
     public ResponseDto<Object> currentUser() {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        UserResponseDto currentUser = userService.getCurrentUser(email);
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        UserResponseDto currentUser = userService.getCurrentUser(userId);
         return ResponseDto.of(currentUser);
     }
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/recipe/controller/RecipeCommentController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/recipe/controller/RecipeCommentController.java
@@ -25,9 +25,9 @@ public class RecipeCommentController {
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "5") int pageSize) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
+        Long userId = AuthenticationHolder.getCurrentUserId();
 
-        return ResponseDto.of(recipeCommentService.pagedCommentsByRecipe(recipeId, email, pageNo, pageSize));
+        return ResponseDto.of(recipeCommentService.pagedCommentsByRecipe(recipeId, userId, pageNo, pageSize));
     }
 
     @AuthenticatedUser
@@ -36,8 +36,8 @@ public class RecipeCommentController {
         @RequestBody RecipeCommentRequestDto requestDto,
         @PathVariable("recipeId") Long recipeId) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeCommentService.create(requestDto, email, recipeId));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeCommentService.create(requestDto, userId, recipeId));
     }
 
     @AuthenticatedUser
@@ -47,8 +47,8 @@ public class RecipeCommentController {
         @PathVariable("commentId") Long commentId,
         @PathVariable String recipeId) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeCommentService.update(commentId, email, requestDto));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeCommentService.update(commentId, userId, requestDto));
     }
 
     @AuthenticatedUser
@@ -57,8 +57,8 @@ public class RecipeCommentController {
         @PathVariable("commentId") Long commentId,
         @PathVariable String recipeId) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        recipeCommentService.delete(commentId, email);
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        recipeCommentService.delete(commentId, userId);
         return ResponseDto.of(null);
     }
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/recipe/dto/RecipeCommentResponseDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/recipe/dto/RecipeCommentResponseDto.java
@@ -17,7 +17,7 @@ public record RecipeCommentResponseDto(
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
-    public static RecipeCommentResponseDto from(RecipeComment recipeComment, Recipe recipe, String email) {
+    public static RecipeCommentResponseDto from(RecipeComment recipeComment, Recipe recipe, Long userId) {
         return RecipeCommentResponseDto.builder()
             .id(recipeComment.getId())
             .postId(recipeComment.getRecipe().getId())
@@ -25,7 +25,7 @@ public record RecipeCommentResponseDto(
             .imageUrl(recipe.getMainImage())
             .title(recipe.getName())
             .email(maskEmail(recipeComment.getUser().getEmail()))
-            .isOwnedByUser(recipeComment.getUser().getEmail().equals(email))
+            .isOwnedByUser(recipeComment.getUser().getId().equals(userId))
             .createdAt(recipeComment.getCreatedAt())
             .updatedAt(recipeComment.getUpdatedAt())
             .build();

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/recipe/repository/RecipeCommentRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/comment/recipe/repository/RecipeCommentRepository.java
@@ -14,8 +14,8 @@ public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Lo
 
     Page<RecipeComment> findByRecipeId(Long recipeId, Pageable pageable);
 
-    @Query("SELECT rc FROM RecipeComment rc JOIN FETCH rc.recipe WHERE rc.user.email = :email ORDER BY rc.updatedAt DESC")
-    Page<RecipeComment> findByUserEmailWithRecipe(@Param("email") String email, Pageable pageable);
+    @Query("SELECT rc FROM RecipeComment rc JOIN FETCH rc.recipe WHERE rc.user.id = :userId ORDER BY rc.updatedAt DESC")
+    Page<RecipeComment> findByUserIdWithRecipe(@Param("userId") Long userId, Pageable pageable);
 
     int countByRecipeId(Long recipeId);
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityController.java
@@ -25,8 +25,8 @@ public class CommunityController {
     @Operation(summary = "게시물 단일 조회")
     @GetMapping("/{id}")
     public ResponseDto<CommunityResponseDto> getCommunityById(@PathVariable Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityService.getCommunityById(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.getCommunityById(id, userId));
     }
 
     @Operation(summary = "게시물 목록 조회")
@@ -35,16 +35,16 @@ public class CommunityController {
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "10") int pageSize) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityService.pagesByCommunity(pageNo, pageSize, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.pagesByCommunity(pageNo, pageSize, userId));
     }
 
     @Operation(summary = "수정 페이지용 게시물 조회")
     @AuthenticatedUser
     @GetMapping("/edit/{id}")
     public ResponseDto<CommunityResponseDto> getPostForEdit(@PathVariable Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityService.getPostForEdit(id, email), "게시물을 성공적으로 가져왔습니다.");
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.getPostForEdit(id, userId), "게시물을 성공적으로 가져왔습니다.");
     }
 
     @Operation(summary = "게시물 작성")
@@ -55,8 +55,8 @@ public class CommunityController {
         @RequestParam(value = "file", required = false) MultipartFile file
     ) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityService.createCommunity(requestDto, file, email), "게시물이 성공적으로 생성되었습니다.");
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.createCommunity(requestDto, file, userId), "게시물이 성공적으로 생성되었습니다.");
     }
 
     @Operation(summary = "게시물 수정")
@@ -67,16 +67,16 @@ public class CommunityController {
         @RequestParam(value = "file", required = false) MultipartFile file,
         @PathVariable("id") Long id) {
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityService.updateCommunity(id, requestDto, file, email), "게시물이 성공적으로 수정되었습니다.");
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.updateCommunity(id, requestDto, file, userId), "게시물이 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "게시물 삭제")
     @AuthenticatedUser
     @DeleteMapping("/{id}")
     public ResponseDto<Void> delete(@PathVariable("id") Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        communityService.deleteCommunity(id, email);
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        communityService.deleteCommunity(id, userId);
         return ResponseDto.of(null, "게시물이 성공적으로 삭제되었습니다.");
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/dto/CommunityResponseDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/dto/CommunityResponseDto.java
@@ -21,21 +21,21 @@ public record CommunityResponseDto(
     public static final String DEFAULT_IMAGE_URL =
         "https://storage.googleapis.com/nangpago-9d371.firebasestorage.app/dc137676-6240-4920-97d3-727c4b7d6d8d_360_F_517535712_q7f9QC9X6TQxWi6xYZZbMmw5cnLMr279.jpg";
 
-    public static CommunityResponseDto of(Community community, String email) {
+    public static CommunityResponseDto of(Community community, Long userId) {
         return CommunityResponseDto.builder()
             .id(community.getId())
             .title(community.getTitle())
             .content(community.getContent())
             .imageUrl(getImageUrlOrDefault(community.getImageUrl()))
             .email(maskEmail(community.getUser().getEmail()))
-            .isOwnedByUser(community.getUser().getEmail().equals(email))
+            .isOwnedByUser(community.getUser().getId().equals(userId))
             .isPublic(community.isPublic())
             .createdAt(community.getCreatedAt())
             .updatedAt(community.getUpdatedAt())
             .build();
     }
 
-    public static CommunityResponseDto of(Community community, int likeCount, int commentCount, String email) {
+    public static CommunityResponseDto of(Community community, int likeCount, int commentCount, Long userId) {
         return CommunityResponseDto.builder()
             .id(community.getId())
             .title(community.getTitle())
@@ -44,7 +44,7 @@ public record CommunityResponseDto(
             .email(maskEmail(community.getUser().getEmail()))
             .likeCount(likeCount)
             .commentCount(commentCount)
-            .isOwnedByUser(community.getUser().getEmail().equals(email))
+            .isOwnedByUser(community.getUser().getId().equals(userId))
             .isPublic(community.isPublic())
             .createdAt(community.getCreatedAt())
             .updatedAt(community.getUpdatedAt())

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/repository/CommunityRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/repository/CommunityRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
-    Page<Community> findByIsPublicTrue(Pageable pageable);
-    Page<Community> findByIsPublicTrueOrUserEmail(String email, Pageable pageable);
+    Page<Community> findByIsPublicTrueOrUserId(Long userId, Pageable pageable);
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/controller/UserController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/controller/UserController.java
@@ -108,8 +108,8 @@ public class UserController {
             throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
         }
 
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getMyComments(email, pageNo - 1, pageSize));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(userService.getMyComments(userId, pageNo - 1, pageSize));
     }
 
     @AuthenticatedUser

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/repository/UserRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/repository/UserRepository.java
@@ -10,7 +10,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Boolean existsByEmail(String email);
-
     Boolean existsByNickname(String nickname);
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserService.java
@@ -35,8 +35,8 @@ public class UserService {
     private final RecipeCommentRepository recipeCommentRepository;
     private final RefrigeratorRepository refrigeratorRepository;
 
-    public UserResponseDto getCurrentUser(String email) {
-        return UserResponseDto.from(userRepository.findByEmail(email)
+    public UserResponseDto getCurrentUser(Long userId) {
+        return UserResponseDto.from(userRepository.findById(userId)
             .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of));
     }
 
@@ -75,11 +75,11 @@ public class UserService {
         );
     }
 
-    public PageDto<RecipeCommentResponseDto> getMyComments(String email, int pageNo, int pageSize) {
+    public PageDto<RecipeCommentResponseDto> getMyComments(Long userId, int pageNo, int pageSize) {
         return PageDto.of(
-            recipeCommentRepository.findByUserEmailWithRecipe(email, PageRequest.of(pageNo, pageSize))
+            recipeCommentRepository.findByUserIdWithRecipe(userId, PageRequest.of(pageNo, pageSize))
                 .map(recipeComment -> {
-                    return RecipeCommentResponseDto.from(recipeComment, recipeComment.getRecipe(), email);
+                    return RecipeCommentResponseDto.from(recipeComment, recipeComment.getRecipe(), userId);
                 })
         );
     }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/recipe/service/RecipeCommentServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/recipe/service/RecipeCommentServiceTest.java
@@ -62,7 +62,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
 
         // when
         PageDto<RecipeCommentResponseDto> pageDto = recipeCommentService.pagedCommentsByRecipe(recipe.getId(),
-            user.getEmail(), pageNo, pageSize);
+            user.getId(), pageNo, pageSize);
 
         //then
         assertThat(pageDto)
@@ -83,7 +83,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         RecipeCommentRequestDto requestDto = new RecipeCommentRequestDto("댓글 작성 예시");
 
         // when
-        RecipeCommentResponseDto responseDto = recipeCommentService.create(requestDto, user.getEmail(), recipe.getId());
+        RecipeCommentResponseDto responseDto = recipeCommentService.create(requestDto, user.getId(), recipe.getId());
 
         // then
         assertThat(responseDto)
@@ -107,7 +107,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         RecipeCommentRequestDto requestDto = new RecipeCommentRequestDto(updateText); // 텍스트 변경
 
         // when
-        RecipeCommentResponseDto responseDto = recipeCommentService.update(comment.getId(), user.getEmail(),
+        RecipeCommentResponseDto responseDto = recipeCommentService.update(comment.getId(), user.getId(),
             requestDto);
 
         // then
@@ -128,7 +128,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         recipeCommentRepository.save(comment);
 
         // when
-        recipeCommentService.delete(comment.getId(), user.getEmail());
+        recipeCommentService.delete(comment.getId(), user.getId());
 
         // then
         assertThat(recipeCommentRepository.existsById(comment.getId()))
@@ -147,10 +147,10 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         recipeRepository.save(recipe);
         recipeCommentRepository.save(comment);
 
-        String anotherUserEmail = "another@nangpago.com";
+        Long anotherUserId = 9999L;
 
         // when, then
-        assertThatThrownBy(() -> recipeCommentService.delete(comment.getId(), anotherUserEmail))
+        assertThatThrownBy(() -> recipeCommentService.delete(comment.getId(), anotherUserId))
             .isInstanceOf(NPGException.class)
             .hasMessage("댓글을 수정/삭제할 권한이 없습니다.");
     }
@@ -165,7 +165,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         RecipeCommentRequestDto requestDto = new RecipeCommentRequestDto("댓글 작성 예시");
 
         // when, then
-        assertThatThrownBy(() -> recipeCommentService.create(requestDto, user.getEmail(), 1L))
+        assertThatThrownBy(() -> recipeCommentService.create(requestDto, user.getId(), 1L))
             .isInstanceOf(NPGException.class)
             .hasMessage("레시피를 찾을 수 없습니다.");
     }
@@ -180,7 +180,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         RecipeCommentRequestDto requestDto = new RecipeCommentRequestDto("댓글 작성 예시");
 
         // when, then
-        assertThatThrownBy(() -> recipeCommentService.create(requestDto, "dummy@nangpago.com", recipe.getId()))
+        assertThatThrownBy(() -> recipeCommentService.create(requestDto, 9999L, recipe.getId()))
             .isInstanceOf(NPGException.class)
             .hasMessage("사용자를 찾을 수 없습니다.");
     }
@@ -201,7 +201,7 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
         RecipeCommentRequestDto requestDto = new RecipeCommentRequestDto(updateText); // 텍스트 변경
 
         // when, then
-        assertThatThrownBy(() -> recipeCommentService.update(1L, user.getEmail(), requestDto))
+        assertThatThrownBy(() -> recipeCommentService.update(1L, user.getId(), requestDto))
             .isInstanceOf(NPGException.class)
             .hasMessage("댓글을 찾을 수 없습니다.");
     }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/repository/CommunityRepositoryTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/repository/CommunityRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.mars.app.domain.community.repository;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.mars.app.support.AbstractRepositoryTestSupport;
+import com.mars.common.model.community.Community;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+class CommunityRepositoryTest extends AbstractRepositoryTestSupport {
+
+    @Autowired
+    private CommunityRepository communityRepository;
+
+    @DisplayName("findByIsPublicTrueOrUserId 테스트")
+    @Test
+    void findByIsPublicTrueOrUserIdTest() {
+        // given
+        Long userId = 6L;
+        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(DESC, "createdAt"));
+        // when
+        Page<Community> byIsPublicTrueOrUserId = communityRepository.findByIsPublicTrueOrUserId(userId, pageRequest);
+
+        // then
+        if (!byIsPublicTrueOrUserId.isEmpty()) {
+            for (Community community : byIsPublicTrueOrUserId) {
+                System.out.println("Community title: " + community.getTitle()
+                    + " / userId: " + community.getUser().getId()
+                    + " / isPublic: " + community.isPublic());
+            }
+        }
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityServiceTest.java
@@ -8,12 +8,15 @@ import com.mars.app.domain.community.repository.CommunityRepository;
 import com.mars.app.domain.firebase.service.FirebaseStorageService;
 import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.support.IntegrationTestSupport;
+import com.mars.common.dto.PageDto;
 import com.mars.common.model.community.Community;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.mars.common.model.user.User;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -66,7 +69,7 @@ class CommunityServiceTest extends IntegrationTestSupport {
         );
 
         // when
-        CommunityResponseDto result = communityService.createCommunity(requestDto, null, user.getEmail());
+        CommunityResponseDto result = communityService.createCommunity(requestDto, null, user.getId());
 
         // then
         assertThat(result.title()).isEqualTo("테스트제목");
@@ -91,13 +94,48 @@ class CommunityServiceTest extends IntegrationTestSupport {
         communityRepository.save(community);
 
         // when
-        CommunityResponseDto result = communityService.getCommunityById(community.getId(), "other@example.com");
+        CommunityResponseDto result = communityService.getCommunityById(community.getId(), 9999L);
 
         // then
         assertThat(result.title()).isEqualTo("공개제목");
         assertThat(result.content()).isEqualTo("공개내용");
         assertThat(result.isOwnedByUser()).isFalse(); //작성자 아님
         assertThat(result.isPublic()).isTrue(); //공개글
+    }
+
+    @DisplayName("공개상태인 게시글과 내가 작성한 게시글을 리스트로 조회할 수 있다.")
+    @Test
+    void getPagesByCommunity() {
+        // given
+        User user = createUser("author@example.com");
+        User userOther = createUser("other@example.com");
+        userRepository.saveAll(List.of(user, userOther));
+
+        Community communityPublic = Community.of(user, "공개제목", "공개내용", null, true);
+        Community communityPrivate = Community.of(user, "비공개제목", "비공개내용", null, false);
+        Community communityOtherAuthorPublic = Community.of(userOther, "공개제목 다른 유저", "공개내용 다른 유저", null, true);
+        Community communityOtherAuthorPrivate = Community.of(userOther, "비공개제목 다른 유저", "비공개내용 다른 유저", null, false);
+        communityRepository.saveAll(List.of(
+            communityPublic,
+            communityPrivate,
+            communityOtherAuthorPublic,
+            communityOtherAuthorPrivate
+        ));
+
+        int pageNo = 0;
+        int pageSize = 5;
+
+        // when
+        PageDto<CommunityResponseDto> communityResponseDtoPageDto = communityService.pagesByCommunity(pageNo, pageSize,
+            user.getId());
+
+        // then
+        assertThat(communityResponseDtoPageDto)
+            .extracting(PageDto::getTotalPages, PageDto::getTotalItems)
+            .containsExactly(1, 3L);
+        assertThat(communityResponseDtoPageDto.getContent())
+            .extracting(CommunityResponseDto::id)
+            .doesNotContain(communityOtherAuthorPrivate.getId());
     }
 
     @DisplayName("비공개 글을 작성자가 아닌 다른 사용자가 조회하면 예외가 발생한다.")
@@ -113,7 +151,7 @@ class CommunityServiceTest extends IntegrationTestSupport {
         // when , then
         Exception ex = assertThrows(
             RuntimeException.class,
-            () -> communityService.getCommunityById(privateCommunity.getId(), "other@example.com")
+            () -> communityService.getCommunityById(privateCommunity.getId(), 9999L)
         );
         assertThat(ex.getMessage()).contains("게시물을 수정/삭제할 권한이 없습니다.");
     }
@@ -140,7 +178,7 @@ class CommunityServiceTest extends IntegrationTestSupport {
             community.getId(),
             updateDto,
             null,
-            user.getEmail()
+            user.getId()
         );
 
         // then
@@ -162,7 +200,7 @@ class CommunityServiceTest extends IntegrationTestSupport {
         communityRepository.save(community);
 
         // when
-        communityService.deleteCommunity(community.getId(), user.getEmail());
+        communityService.deleteCommunity(community.getId(), user.getId());
 
         // then
         boolean exists = communityRepository.existsById(community.getId());

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/user/User.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/user/User.java
@@ -32,6 +32,8 @@ import lombok.NoArgsConstructor;
 @Entity
 public class User extends BaseEntity {
 
+    public static final Long ANONYMOUS_USER_ID = -1L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -67,9 +69,8 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecipeFavorite> favorites;
 
-    public User updateNickname(UserInfoRequestDto requestDto) {
+    public void updateNickname(UserInfoRequestDto requestDto) {
         this.nickname = requestDto.nickname();
-        return this;
     }
 
     public void softDelete(){


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- `@AuthenticatedUser`를 이용한 인증 시, 미인증 상태를 `null`로 반환하는 대신 `-1L`을 상수로 선언(`User.ANONYMOUS_USER_ID`) 하여 NPE를 방지하고 후처리 로직에서 활용할 수 있게 변경.
- RecipeComment, Community 관련 코드에 `findById` 리팩터링 적용
  - 한번에 다 수정하면, 다른 PR과 충돌났을 때 해결하기 힘들 것 같아 부분 PR로 나눠서 병합시킬 예정

## PR 유형

- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).