### PR TITLE
[NPG-210] User 인증 로직에서 `findByEmail()` 제거

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/component/auth/AuthenticationHolder.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/component/auth/AuthenticationHolder.java
@@ -10,14 +10,6 @@ import org.springframework.stereotype.Component;
 public class AuthenticationHolder {
     private AuthenticationHolder() { }
 
-    public static String getCurrentUserEmail() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
-            return userDetails.getUsername();
-        }
-        return "anonymous_user";
-    }
-
     public static Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityLikeController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityLikeController.java
@@ -26,16 +26,16 @@ public class CommunityLikeController {
     @AuthenticatedUser
     @GetMapping("/{id}/like/status")
     public ResponseDto<Boolean> getCommunityLikeStatus(@PathVariable Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityLikeService.isLiked(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityLikeService.isLiked(id, userId));
     }
 
     @Operation(summary = "게시물 좋아요 토글 버튼")
     @AuthenticatedUser
     @PostMapping("/{id}/like/toggle")
     public ResponseDto<CommunityLikeResponseDto> toggleCommunityLike(@PathVariable Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(communityLikeService.toggleLike(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityLikeService.toggleLike(id, userId));
     }
 
     @Operation(summary = "게시물 좋아요 개수 조회")

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/repository/CommunityLikeRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/repository/CommunityLikeRepository.java
@@ -16,8 +16,8 @@ public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Lo
     @Lock(PESSIMISTIC_WRITE)
     Optional<CommunityLike> findByUserAndCommunity(User user, Community community);
 
-    @Query("SELECT clike FROM CommunityLike clike WHERE clike.user.email = :email AND clike.community.id = :communityId")
-    Optional<CommunityLike> findByEmailAndCommunityId(@Param("email") String email, @Param("communityId") Long communityId);
+    @Query("SELECT clike FROM CommunityLike clike WHERE clike.user.id = :userId AND clike.community.id = :communityId")
+    Optional<CommunityLike> findByUserIdAndCommunityId(@Param("userId") Long userId, @Param("communityId") Long communityId);
 
     int countByCommunityId(Long communityId);
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/controller/RecipeFavoriteController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/controller/RecipeFavoriteController.java
@@ -26,16 +26,16 @@ public class RecipeFavoriteController {
     @Operation(summary = "즐겨찾기 상태 확인")
     @GetMapping("/{id}/favorite/status")
     public ResponseDto<Boolean> isFavorite(@PathVariable("id") Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeFavoriteService.isFavorite(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeFavoriteService.isFavorite(id, userId));
     }
 
     @Operation(summary = "즐겨찾기 상태 변경")
     @AuthenticatedUser
     @PostMapping("/{id}/favorite/toggle")
     public ResponseDto<RecipeFavoriteResponseDto> toggleFavorite(@PathVariable("id") Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeFavoriteService.toggleFavorite(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeFavoriteService.toggleFavorite(id, userId));
     }
 
     @Operation(summary = "즐겨찾기 목록 조회")
@@ -51,7 +51,7 @@ public class RecipeFavoriteController {
         if (pageSize < 1) {
             throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
         }
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeFavoriteService.getFavoriteRecipes(email, pageNo - 1, pageSize));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeFavoriteService.getFavoriteRecipes(userId, pageNo - 1, pageSize));
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/repository/RecipeFavoriteRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/repository/RecipeFavoriteRepository.java
@@ -23,8 +23,8 @@ public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, 
     @Query("SELECT rf FROM RecipeFavorite rf WHERE rf.user = :user")
     Page<RecipeFavorite> findAllByUser(@Param("user") User user, Pageable pageable);
 
-    @Query("SELECT rf FROM RecipeFavorite rf WHERE rf.user.email = :email AND rf.recipe.id = :recipeId")
-    Optional<RecipeFavorite> findByEmailAndRecipeId(@Param("email") String email, @Param("recipeId") Long recipeId);
+    @Query("SELECT rf FROM RecipeFavorite rf WHERE rf.user.id = :userId AND rf.recipe.id = :recipeId")
+    Optional<RecipeFavorite> findByUserIdAndRecipeId(@Param("userId") Long userId, @Param("recipeId") Long recipeId);
 
     int countByUser(User user);
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/controller/RecipeController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/controller/RecipeController.java
@@ -45,15 +45,15 @@ public class RecipeController {
     @AuthenticatedUser
     @GetMapping("/{id}/like/status")
     public ResponseDto<Boolean> getRecipeLikeStatus(@PathVariable Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeLikeService.isLiked(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeLikeService.isLiked(id, userId));
     }
 
     @AuthenticatedUser
     @PostMapping("/{id}/like/toggle")
     public ResponseDto<RecipeLikeResponseDto> toggleRecipeLike(@PathVariable Long id) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(recipeLikeMessageService.toggleLike(id, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(recipeLikeMessageService.toggleLike(id, userId));
     }
 
     @GetMapping("/{id}/like/count")

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/dto/RecipeLikeMessageDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/dto/RecipeLikeMessageDto.java
@@ -5,12 +5,12 @@ import lombok.Builder;
 @Builder
 public record RecipeLikeMessageDto(
     Long recipeId,
-    String email
+    Long userId
 ) {
-    public static RecipeLikeMessageDto of(Long recipeId, String email) {
+    public static RecipeLikeMessageDto of(Long recipeId, Long userId) {
         return RecipeLikeMessageDto.builder()
             .recipeId(recipeId)
-            .email(email)
+            .userId(userId)
             .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/messaging/LikeNotificationPublisher.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/messaging/LikeNotificationPublisher.java
@@ -15,8 +15,8 @@ public class LikeNotificationPublisher {
     private final TopicExchange topicExchange;
     private final RabbitTemplate rabbitTemplate;
 
-    public void sendLikeNotification(Long recipeId, String email) {
-        RecipeLikeMessageDto recipeLikeMessageDto = RecipeLikeMessageDto.of(recipeId, email);
+    public void sendLikeNotification(Long recipeId, Long userId) {
+        RecipeLikeMessageDto recipeLikeMessageDto = RecipeLikeMessageDto.of(recipeId, userId);
 
         rabbitTemplate.convertAndSend(topicExchange.getName(), LIKE_ROUTING_KEY, recipeLikeMessageDto);
     }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/repository/RecipeLikeRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/repository/RecipeLikeRepository.java
@@ -14,8 +14,8 @@ public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
 
     Optional<RecipeLike> findByUserAndRecipe(User user, Recipe recipe);
 
-    @Query("SELECT rl FROM RecipeLike rl WHERE rl.user.email = :email AND rl.recipe.id = :recipeId")
-    Optional<RecipeLike> findByEmailAndRecipeId(@Param("email") String email, @Param("recipeId") Long recipeId);
+    @Query("SELECT rl FROM RecipeLike rl WHERE rl.user.id = :userId AND rl.recipe.id = :recipeId")
+    Optional<RecipeLike> findByUserIdAndRecipeId(@Param("userId") Long userId, @Param("recipeId") Long recipeId);
 
     Page<RecipeLike> findRecipeLikeByUser(User user, Pageable pageable);
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/service/RecipeLikeMessageService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/service/RecipeLikeMessageService.java
@@ -11,9 +11,9 @@ public class RecipeLikeMessageService {
 
     private final LikeNotificationPublisher likeNotificationPublisher;
 
-    public RecipeLikeResponseDto toggleLike(Long recipeId, String email) {
+    public RecipeLikeResponseDto toggleLike(Long recipeId, Long userId) {
         // Message 전송 to RabbitMQ
-        likeNotificationPublisher.sendLikeNotification(recipeId, email);
+        likeNotificationPublisher.sendLikeNotification(recipeId, userId);
 
         return RecipeLikeResponseDto.of(recipeId);
     }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/service/RecipeLikeService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/service/RecipeLikeService.java
@@ -12,8 +12,8 @@ public class RecipeLikeService {
 
     private final RecipeLikeRepository recipeLikeRepository;
 
-    public boolean isLiked(Long recipeId, String email) {
-        return recipeLikeRepository.findByEmailAndRecipeId(email, recipeId).isPresent();
+    public boolean isLiked(Long recipeId, Long userId) {
+        return recipeLikeRepository.findByUserIdAndRecipeId(userId, recipeId).isPresent();
     }
 
     public int getLikeCount(Long recipeId) {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/refrigerator/controller/RefrigeratorController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/refrigerator/controller/RefrigeratorController.java
@@ -22,20 +22,20 @@ public class RefrigeratorController {
     @AuthenticatedUser
     @GetMapping
     public ResponseDto<List<RefrigeratorResponseDto>> getRefrigerator() {
-        return ResponseDto.of(refrigeratorService.findRefrigerator(AuthenticationHolder.getCurrentUserEmail()));
+        return ResponseDto.of(refrigeratorService.findRefrigerator(AuthenticationHolder.getCurrentUserId()));
     }
 
     @AuthenticatedUser
     @PostMapping
     public ResponseDto<RefrigeratorResponseDto> addIngredient(@RequestParam(name = "ingredientName") String ingredientName) {
-        refrigeratorService.addIngredient(AuthenticationHolder.getCurrentUserEmail(), ingredientName);
+        refrigeratorService.addIngredient(AuthenticationHolder.getCurrentUserId(), ingredientName);
         return ResponseDto.of(RefrigeratorResponseDto.from(ingredientName));
     }
 
     @AuthenticatedUser
     @DeleteMapping
     public ResponseDto<RefrigeratorResponseDto> deleteMyIngredient(@RequestParam(name = "ingredientName") String ingredientName) {
-        refrigeratorService.deleteIngredient(AuthenticationHolder.getCurrentUserEmail(), ingredientName);
+        refrigeratorService.deleteIngredient(AuthenticationHolder.getCurrentUserId(), ingredientName);
         return ResponseDto.of(RefrigeratorResponseDto.from(ingredientName));
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/refrigerator/repository/RefrigeratorRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/refrigerator/repository/RefrigeratorRepository.java
@@ -11,14 +11,14 @@ import org.springframework.data.repository.query.Param;
 
 public interface RefrigeratorRepository extends JpaRepository<Refrigerator, Long> {
 
-    @Query("SELECT r FROM Refrigerator r " + "JOIN FETCH r.ingredient i " + "WHERE r.user.email = :email")
-    List<Refrigerator> findByUserEmail(@Param("email") String email);
+    @Query("SELECT r FROM Refrigerator r " + "JOIN FETCH r.ingredient i " + "WHERE r.user.id = :userId")
+    List<Refrigerator> findByUserId(@Param("userId") Long userId);
 
     boolean existsByUserAndIngredient(User user, Ingredient ingredient);
 
     @Modifying
-    @Query("DELETE FROM Refrigerator r WHERE r.user.email = :email AND r.ingredient.name = :ingredientName")
-    void deleteByUserEmailAndIngredientName(@Param("email") String email, @Param("ingredientName") String ingredientName);
+    @Query("DELETE FROM Refrigerator r WHERE r.user.id = :userId AND r.ingredient.name = :ingredientName")
+    void deleteByUserIdAndIngredientName(@Param("userId") Long userId, @Param("ingredientName") String ingredientName);
 
     int countByUser(User user);
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/controller/UserController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/controller/UserController.java
@@ -38,8 +38,8 @@ public class UserController {
     @AuthenticatedUser
     @GetMapping("/my-page")
     public ResponseDto<MyPageDto> findMyPage() {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        MyPageDto myPageDto = userService.getMyPage(email);
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        MyPageDto myPageDto = userService.getMyPage(userId);
 
         return ResponseDto.of(myPageDto);
     }
@@ -47,8 +47,8 @@ public class UserController {
     @AuthenticatedUser
     @GetMapping("/profile")
     public ResponseDto<UserInfoResponseDto> findUserInfo() {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getUserInfo(email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(userService.getUserInfo(userId));
     }
 
     @AuthenticatedUser
@@ -60,8 +60,8 @@ public class UserController {
     @AuthenticatedUser
     @PutMapping("/profile")
     public ResponseDto<UserInfoResponseDto> updateUserInfo(@RequestBody UserInfoRequestDto requestDto) {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.updateUserInfo(requestDto, email));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(userService.updateUserInfo(requestDto, userId));
     }
 
     @GetMapping("/recipe/like")
@@ -75,8 +75,8 @@ public class UserController {
         if (pageSize < 1) {
             throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
         }
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getMyLikedRecipes(email, pageNo - 1, pageSize));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(userService.getMyLikedRecipes(userId, pageNo - 1, pageSize));
     }
 
     @AuthenticatedUser
@@ -91,8 +91,8 @@ public class UserController {
         if (pageSize < 1) {
             throw NPGExceptionType.BAD_REQUEST_INVALID_PAGE_SIZE.of();
         }
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        return ResponseDto.of(userService.getMyFavorites(email, pageNo - 1, pageSize));
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(userService.getMyFavorites(userId, pageNo - 1, pageSize));
     }
 
     @AuthenticatedUser
@@ -115,8 +115,8 @@ public class UserController {
     @AuthenticatedUser
     @GetMapping("/deactivate")
     public ResponseDto<String> deactivateUser() throws IOException, InterruptedException {
-        String email = AuthenticationHolder.getCurrentUserEmail();
-        oauth2ProviderTokenService.deactivateUser(email);
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        oauth2ProviderTokenService.deactivateUser(userId);
         return ResponseDto.of("");
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserService.java
@@ -40,9 +40,8 @@ public class UserService {
             .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of));
     }
 
-    public MyPageDto getMyPage(String email) {
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of);
+    public MyPageDto getMyPage(Long userId) {
+        User user = findUserById(userId);
 
         int likeCount = recipeLikeRepository.countByUser(user);
         int favoriteCount = recipeFavoriteRepository.countByUser(user);
@@ -56,16 +55,16 @@ public class UserService {
         );
     }
 
-    public PageDto<RecipeResponseDto> getMyLikedRecipes(String email, int pageNo, int pageSize) {
+    public PageDto<RecipeResponseDto> getMyLikedRecipes(Long userId, int pageNo, int pageSize) {
         return PageDto.of(
-            recipeLikeRepository.findRecipeLikeByUser(findUserByEmail(email), PageRequest.of(pageNo, pageSize))
+            recipeLikeRepository.findRecipeLikeByUser(findUserById(userId), PageRequest.of(pageNo, pageSize))
                 .map(recipeLike -> RecipeResponseDto.from(recipeLike.getRecipe()))
         );
     }
 
-    public PageDto<RecipeFavoriteListResponseDto> getMyFavorites(String email, int pageNo, int pageSize) {
+    public PageDto<RecipeFavoriteListResponseDto> getMyFavorites(Long userId, int pageNo, int pageSize) {
         return PageDto.of(
-            recipeFavoriteRepository.findAllByUser(findUserByEmail(email), PageRequest.of(pageNo, pageSize))
+            recipeFavoriteRepository.findAllByUser(findUserById(userId), PageRequest.of(pageNo, pageSize))
                 .map(recipeFavorite -> {
                     Recipe recipe = recipeFavorite.getRecipe();
                     int likeCount = recipeLikeRepository.countByRecipeId(recipe.getId());
@@ -84,8 +83,8 @@ public class UserService {
         );
     }
 
-    public UserInfoResponseDto getUserInfo(String email) {
-        return UserInfoResponseDto.from(findUserByEmail(email));
+    public UserInfoResponseDto getUserInfo(Long userId) {
+        return UserInfoResponseDto.from(findUserById(userId));
     }
 
     public boolean isNicknameAvailable(String targetNickname) {
@@ -94,11 +93,11 @@ public class UserService {
     }
 
     @Transactional
-    public UserInfoResponseDto updateUserInfo(UserInfoRequestDto requestDto, String email) {
+    public UserInfoResponseDto updateUserInfo(UserInfoRequestDto requestDto, Long userId) {
         String targetNickname = requestDto.nickname().trim();
         validateNickname(targetNickname);
 
-        User updatedUser = updateNickname(requestDto, email);
+        User updatedUser = updateNickname(requestDto, userId);
         return UserInfoResponseDto.from(updatedUser);
     }
 
@@ -120,15 +119,15 @@ public class UserService {
         return userRepository.existsByNickname(nickname);
     }
 
-    private User updateNickname(UserInfoRequestDto requestDto, String email) {
-        User user = findUserByEmail(email);
+    private User updateNickname(UserInfoRequestDto requestDto, Long userId) {
+        User user = findUserById(userId);
         user.updateNickname(requestDto);
 
         return user;
     }
 
-    private User findUserByEmail(String email){
-        return userRepository.findByEmail(email)
-            .orElseThrow(NPGExceptionType.UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT::of);
+    private User findUserById(Long userId){
+        return userRepository.findById(userId)
+            .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of);
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityLikeServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityLikeServiceTest.java
@@ -64,7 +64,7 @@ class CommunityLikeServiceTest extends IntegrationTestSupport {
         communityRepository.save(community);
 
         // when: 처음 좋아요를 누름
-        var response = communityLikeService.toggleLike(community.getId(), user.getEmail());
+        var response = communityLikeService.toggleLike(community.getId(), user.getId());
 
         // then: 좋아요 상태가 true로 변경됨
         assertThat(response.liked()).isTrue();
@@ -84,7 +84,7 @@ class CommunityLikeServiceTest extends IntegrationTestSupport {
         communityLikeRepository.save(communityLike);
 
         // when : 좋아요를 다시 누름
-        var response = communityLikeService.toggleLike(community.getId(), user.getEmail());
+        var response = communityLikeService.toggleLike(community.getId(), user.getId());
 
         // then : 좋아요 상태가 false로 변경됨
         assertThat(response.liked()).isFalse();
@@ -106,7 +106,7 @@ class CommunityLikeServiceTest extends IntegrationTestSupport {
         communityLikeRepository.save(like);
 
         // when
-        boolean liked = communityLikeService.isLiked(community.getId(), user.getEmail());
+        boolean liked = communityLikeService.isLiked(community.getId(), user.getId());
 
         // then
         assertThat(liked).isTrue();

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
@@ -52,7 +52,7 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
 
         // when
         RecipeFavoriteResponseDto favoriteResponseDto = recipeFavoriteService.toggleFavorite(recipe.getId(),
-            user.getEmail());
+            user.getId());
 
         // then
         assertThat(favoriteResponseDto)
@@ -74,7 +74,7 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
 
         // when
         RecipeFavoriteResponseDto favoriteResponseDto = recipeFavoriteService.toggleFavorite(recipe.getId(),
-            user.getEmail());
+            user.getId());
 
         // then
         assertThat(favoriteResponseDto)
@@ -95,7 +95,7 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
         recipeFavoriteRepository.save(recipeFavorite);
 
         // when
-        boolean favorite = recipeFavoriteService.isFavorite(recipe.getId(), user.getEmail());
+        boolean favorite = recipeFavoriteService.isFavorite(recipe.getId(), user.getId());
 
         // then
         assertThat(favorite).isTrue();
@@ -108,9 +108,9 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
         User user = createUser("dummy@nangpago.com");
         Recipe recipe = createRecipe("파스타");
         recipeRepository.save(recipe);
-        
+
         // when
-        boolean favoriteByUser1 = recipeFavoriteService.isFavorite(recipe.getId(), user.getEmail());
+        boolean favoriteByUser1 = recipeFavoriteService.isFavorite(recipe.getId(), user.getId());
 
         // then
         assertThat(favoriteByUser1).isFalse();
@@ -138,7 +138,7 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
 
         // when
         PageDto<RecipeFavoriteListResponseDto> recipeFavorites = recipeFavoriteService.getFavoriteRecipes(
-            user.getEmail(), 0, 10);
+            user.getId(), 0, 10);
 
         //then
         assertThat(recipeFavorites)
@@ -151,14 +151,13 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
     @Test
     void NotCorrectUserException() {
         // given
-        Recipe recipe = createRecipe("파스타");
+        Long nonExistUserId = 9999L;
 
+        Recipe recipe = createRecipe("파스타");
         recipeRepository.save(recipe);
 
-        String email = "dummy@nangpago.com";
-
         // when, then
-        assertThatThrownBy(() -> recipeFavoriteService.toggleFavorite(recipe.getId(), email))
+        assertThatThrownBy(() -> recipeFavoriteService.toggleFavorite(recipe.getId(), nonExistUserId))
             .isInstanceOf(NPGException.class)
             .hasMessage("사용자를 찾을 수 없습니다.");
     }
@@ -174,7 +173,7 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
         Long recipeId = 1L;
 
         // when, then
-        assertThatThrownBy(() -> recipeFavoriteService.toggleFavorite(recipeId, user.getEmail()))
+        assertThatThrownBy(() -> recipeFavoriteService.toggleFavorite(recipeId, user.getId()))
             .isInstanceOf(NPGException.class)
             .hasMessage("레시피를 찾을 수 없습니다.");
     }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/messaging/LikeNotificationConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/messaging/LikeNotificationConsumerTest.java
@@ -58,13 +58,13 @@ class LikeNotificationConsumerTest extends IntegrationTestSupport {
         userRepository.save(user);
         recipeRepository.save(recipe);
 
-        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getEmail());
+        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getId());
 
         // when
         likeNotificationConsumer.processLikeEvent(messageDto);
 
         // then
-        assertThat(recipeLikeRepository.findByEmailAndRecipeId(user.getEmail(), recipe.getId()))
+        assertThat(recipeLikeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
             .isPresent();
         assertThat(recipeLikeRepository.countByRecipeId(recipe.getId())).isEqualTo(1);
     }
@@ -82,13 +82,13 @@ class LikeNotificationConsumerTest extends IntegrationTestSupport {
         RecipeLike recipeLike = RecipeLike.of(user, recipe);
         recipeLikeRepository.save(recipeLike);
 
-        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getEmail());
+        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getId());
 
         // when
         likeNotificationConsumer.processLikeEvent(messageDto);
 
         // then
-        assertThat(recipeLikeRepository.findByEmailAndRecipeId(user.getEmail(), recipe.getId()))
+        assertThat(recipeLikeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
             .isEmpty();
         assertThat(recipeLikeRepository.countByRecipeId(recipe.getId())).isZero();
     }
@@ -100,7 +100,7 @@ class LikeNotificationConsumerTest extends IntegrationTestSupport {
         Recipe recipe = createRecipe("테스트 레시피");
         recipeRepository.save(recipe);
 
-        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), "invalid@nangpago.com");
+        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), 9999L);
 
         // when & then
         assertThatThrownBy(() -> likeNotificationConsumer.processLikeEvent(messageDto))
@@ -115,7 +115,7 @@ class LikeNotificationConsumerTest extends IntegrationTestSupport {
         User user = createUser("test@nangpago.com");
         userRepository.save(user);
 
-        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(999L, user.getEmail());
+        RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(999L, user.getId());
 
         // when & then
         assertThatThrownBy(() -> likeNotificationConsumer.processLikeEvent(messageDto))

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/repository/RecipeLikeRepositoryTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/repository/RecipeLikeRepositoryTest.java
@@ -33,11 +33,11 @@ class RecipeLikeRepositoryTest extends AbstractRepositoryTestSupport {
     @Test
     void findByUserAndRecipe() {
         // given
-        String email = "dummy@nangpago.com";
+        Long userId = 2L;
         Long recipeId = 2L;
 
         // when
-        Optional<RecipeLike> findRecipeLike = recipeLikeRepository.findByEmailAndRecipeId(email, recipeId);
+        Optional<RecipeLike> findRecipeLike = recipeLikeRepository.findByUserIdAndRecipeId(userId, recipeId);
 
         // then
         findRecipeLike.ifPresent(recipeLike ->

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/service/RecipeLikeMessageServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/service/RecipeLikeMessageServiceTest.java
@@ -21,30 +21,30 @@ class RecipeLikeMessageServiceTest {
     @InjectMocks
     private RecipeLikeMessageService recipeLikeMessageService;
 
-    @DisplayName("좋아요 토글 메시지를 RabbitMQ로 전송한다.")
+    @DisplayName("좋아요 토글 메시지를 RabbitMQ로 전송할 수 있다.")
     @Test
     void toggleLike() {
         // given
         Long recipeId = 1L;
-        String email = "test@nangpago.com";
+        Long userId = 1L;
 
         // when
-        RecipeLikeResponseDto response = recipeLikeMessageService.toggleLike(recipeId, email);
+        RecipeLikeResponseDto response = recipeLikeMessageService.toggleLike(recipeId, userId);
 
         // then
-        verify(likeNotificationPublisher).sendLikeNotification(recipeId, email);
+        verify(likeNotificationPublisher).sendLikeNotification(recipeId, userId);
         assertThat(response.recipeId()).isEqualTo(recipeId);
     }
 
-    @DisplayName("좋아요 토글 응답은 레시피 ID를 포함한다")
+    @DisplayName("좋아요 토글 응답은 레시피 ID를 포함한다.")
     @Test
     void toggleLikeResponse() {
         // given
         Long recipeId = 1L;
-        String email = "test@nangpago.com";
+        Long userId = 1L;
 
         // when
-        RecipeLikeResponseDto response = recipeLikeMessageService.toggleLike(recipeId, email);
+        RecipeLikeResponseDto response = recipeLikeMessageService.toggleLike(recipeId, userId);
 
         // then
         assertThat(response)

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/service/RecipeLikeServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/service/RecipeLikeServiceTest.java
@@ -67,7 +67,7 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
         recipeLikeRepository.save(recipeLike);
 
         // when
-        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user.getEmail());
+        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user.getId());
 
         // then
         assertThat(isLiked).isTrue();
@@ -84,7 +84,7 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
         recipeRepository.save(recipe);
 
         // when
-        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user.getEmail());
+        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user.getId());
 
         // then
         assertThat(isLiked).isFalse();
@@ -109,7 +109,7 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
         recipeLikeRepository.save(recipeLike);
 
         // when
-        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user2.getEmail());
+        boolean isLiked = recipeLikeService.isLiked(recipe.getId(), user2.getId());
 
         // then
         assertThat(isLiked).isFalse();

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/refrigerator/repository/RefrigeratorRepositoryTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/refrigerator/repository/RefrigeratorRepositoryTest.java
@@ -19,14 +19,14 @@ class RefrigeratorRepositoryTest extends AbstractRepositoryTestSupport {
     @Autowired
     private IngredientRepository ingredientRepository;
 
-    @DisplayName("UserEmail로 Refrigerator 테이블 조회")
+    @DisplayName("UserId로 Refrigerator 테이블 조회")
     @Test
     void deleteByUser_EmailAndIngredient_Name() {
         // given
-        String email = "dummy@nangpago.com";
+        Long dummyUserId = 2L;
 
-        // when, 임의로 추가한 데이터 삭제
-        List<Refrigerator> remainingRefrigerators = refrigeratorRepository.findByUserEmail(email);
+        // when
+        List<Refrigerator> remainingRefrigerators = refrigeratorRepository.findByUserId(dummyUserId);
 
         // then
         if (!remainingRefrigerators.isEmpty()) {

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/refrigerator/service/RefrigeratorServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/refrigerator/service/RefrigeratorServiceTest.java
@@ -77,7 +77,7 @@ class RefrigeratorServiceTest extends IntegrationTestSupport {
         refrigeratorRepository.saveAll(List.of(refrigerator1, refrigerator2));
 
         // when
-        List<RefrigeratorResponseDto> result = refrigeratorService.findRefrigerator(email);
+        List<RefrigeratorResponseDto> result = refrigeratorService.findRefrigerator(user.getId());
 
         // then
         assertThat(result).hasSize(2)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 요청 클라이언트의 User 정보 조회 쿼리에서 `email`을 조회 조건으로 사용하던 코드를 전부 `id`로 전환하는 변경을 반영합니다.

## PR 유형

- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).