### PR TITLE
[NPG-202] 관리자 유저 페이지 정렬 기능 추가

### DIFF
--- a/NangPaGo-admin/src/api/usermanage.js
+++ b/NangPaGo-admin/src/api/usermanage.js
@@ -1,8 +1,13 @@
 import axiosInstance from './axiosInstance';
 
-export const getUserList = async (page, asc, sortName) => {
+export const getUserList = async (pageNo, sortType) => {
   try {
-    const response = await axiosInstance.get(`/api/user?page=${page}&asc=${asc}&sortName=${sortName}`);
+    const response = await axiosInstance.get(`/api/user`, {
+      params: {
+        pageNo,
+        sort: sortType
+      }
+    });
     return response.data;
   } catch (error) {
     throw new Error(

--- a/NangPaGo-admin/src/api/usermanage.js
+++ b/NangPaGo-admin/src/api/usermanage.js
@@ -1,8 +1,8 @@
 import axiosInstance from './axiosInstance';
 
-export const getUserList = async (page) => {
+export const getUserList = async (page, asc, sortName) => {
   try {
-    const response = await axiosInstance.get(`/api/user?page=${page}`);
+    const response = await axiosInstance.get(`/api/user?page=${page}&asc=${asc}&sortName=${sortName}`);
     return response.data;
   } catch (error) {
     throw new Error(

--- a/NangPaGo-admin/src/pages/Users.jsx
+++ b/NangPaGo-admin/src/pages/Users.jsx
@@ -4,10 +4,21 @@ import { getUserList, banUser, unBanUser } from '../api/usermanage';
 export default function Users() {
   const [users, setUsers] = useState([]);
   const [currentPage, setCurrentPage] = useState(0);
+  const [isAscending, setIsAscending] = useState(false);
   const [totalPages, setTotalPages] = useState(0);
   const [showConfirm, setShowConfirm] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
   const [actionType, setActionType] = useState("");
+  const [sortField, setSortField] = useState("id");
+
+  const toggleSort = (field) => {
+    if (sortField === field) {
+      setIsAscending(prev => !prev);
+    } else {
+      setSortField(field);
+      setIsAscending(true);
+    }
+  };
 
   const handleStatusChange = (user, newStatus) => {
     setSelectedUser(user);
@@ -35,75 +46,133 @@ export default function Users() {
   };
 
   useEffect(() => {
-      const fetchData = async () => {
-        try {
-          const response = await getUserList(currentPage);
-          console.log(response.data); // 확인용 로그
-          setUsers(response.data.content); // 사용자 목록
-          setTotalPages(response.data.totalPages); // 총 페이지 수
-        } catch (error) {
-          console.error('데이터 가져오기 에러: ', error);
-        }
-      };
-      fetchData();
-    }, [currentPage]);
+    const fetchData = async () => {
+      try {
+        const response = await getUserList(currentPage, isAscending, sortField);
+        setUsers(response.data.content);
+        setTotalPages(response.data.totalPages);
+      } catch (error) {
+        console.error('데이터 가져오기 에러: ', error);
+      }
+    };
+    fetchData();
+  }, [currentPage, isAscending, sortField]);
 
   return (
     <div className="p-6">
       <h2 className="text-2xl font-semibold text-gray-900 mb-6">사용자 관리</h2>
-      <div className="bg-white p-4 rounded-md shadow-md h-[800px] flex flex-col">
-      <div className="flex-1 min-h-[580px] overflow-auto">
-          <table className="min-w-full border-collapse">
-            <thead>
+      <div className="bg-white p-4 rounded-md shadow-md flex flex-col">
+        <div className="flex-1 overflow-x-auto">
+          <table className="w-full table-fixed border-collapse min-w-[800px]">
+            <colgroup>
+              <col className="w-[5%]" />{/* ID */}
+              <col className="w-[20%]" />{/* 이메일 */}
+              <col className="w-[13%]" />{/* 닉네임 */}
+              <col className="w-[8%]" />{/* 생년월일 */}
+              <col className="w-[9%]" />{/* 전화번호 */}
+              <col className="w-[7%]" />{/* 가입 경로 */}
+              <col className="w-[12%]" />{/* 가입일 */}
+              <col className="w-[12%]" />{/* 수정일 */}
+              <col className="w-[9%]" />{/* 상태 */}
+            </colgroup>
+          <thead>
             <tr>
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">ID</th>
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">이메일</th>
-              <th className="px-4 py-3 text-left text-sm font-semibold border-b">닉네임</th>
+              <th 
+                className="px-4 py-3 text-left text-sm font-semibold border-b cursor-pointer group"
+                onClick={() => toggleSort('nickname')}
+              >
+                <div className="flex items-center">
+                  닉네임
+                  <span className="ml-1">
+                    {sortField === 'nickname' ? (
+                      isAscending ? (
+                        <svg className="w-4 h-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 15l7-7 7 7"/>
+                        </svg>
+                      ) : (
+                        <svg className="w-4 h-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                      )
+                    ) : (
+                      <svg className="w-4 h-4 text-gray-300 group-hover:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
+                      </svg>
+                    )}
+                  </span>
+                </div>
+              </th>
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">생년월일</th>
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">전화번호</th>
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">가입 경로</th>
-              <th className="px-4 py-3 text-left text-sm font-semibold border-b">가입일</th>
-              <th className="px-4 py-3 text-left text-sm font-semibold border-b">수정일</th>
-              <th className="px-4 py-3 text-left text-sm font-semibold border-b w-28">상태</th>
-            </tr>
-            </thead>
-            <tbody>
-            {users.map((user, index) => (
-              <tr
-                key={user.id}
-                className={`${
-                  index % 2 === 0 ? 'bg-gray-100' : 'bg-white'
-                } hover:bg-blue-50 border-b`}
+              <th 
+                className="px-4 py-3 text-left text-sm font-semibold border-b cursor-pointer group"
+                onClick={() => toggleSort('id')}
               >
-                <td className="px-4 py-2 text-sm text-gray-700">{user.id}</td>
-                <td className="px-4 py-2 text-sm text-gray-700">{user.email}</td>
-                <td
-                  className="px-4 py-2 text-sm text-gray-700">{user.nickname}</td>
-                <td className="px-4 py-2 text-sm text-gray-700">{user.birthday || '-'}</td>
-                <td className="px-4 py-2 text-sm text-gray-700">{user.phone || '-'}</td>
-                <td className="px-4 py-2 text-sm text-gray-700">{user.oAuth2Provider}</td>
-                <td className="px-4 py-2 text-sm text-gray-700">{user.createdAt}</td>
-                <td className="px-4 py-2 text-sm text-gray-700">{user.updatedAt}</td>
-                <td className="px-4 py-2 text-sm text-gray-700 w-28">
+                <div className="flex items-center">
+                  가입일
+                  <span className="ml-1">
+                    {sortField === 'id' ? (
+                      isAscending ? (
+                        <svg className="w-4 h-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 15l7-7 7 7"/>
+                        </svg>
+                      ) : (
+                        <svg className="w-4 h-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                      )
+                    ) : (
+                      <svg className="w-4 h-4 text-gray-300 group-hover:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
+                      </svg>
+                    )}
+                  </span>
+                </div>
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-semibold border-b">수정일</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold border-b">상태</th>
+            </tr>
+          </thead>
+            <tbody>
+              {users.map((user, index) => (
+                <tr
+                  key={user.id}
+                  className={`${
+                    index % 2 === 0 ? 'bg-gray-100' : 'bg-white'
+                  } hover:bg-blue-50 border-b`}
+                >
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.id}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.email}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.nickname}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.birthday || '-'}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.phone || '-'}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.oAuth2Provider}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.createdAt}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.updatedAt}</td>
+                  <td className="px-4 py-2 text-sm text-gray-700 w-[120px]">
                   {user.userStatus === 'WITHDRAWN' ? (
-                    <div className="text-gray-500 px-2 py-1">
+                    <div className="text-gray-500 px-2 py-1.5 w-[100px] overflow-hidden whitespace-nowrap text-ellipsis h-[32px] flex items-center border rounded">
                       WITHDRAWN
                     </div>
                   ) : (
-                  <select
-                    value={user.userStatus}
-                    onChange={(e) => handleStatusChange(user, e.target.value)}
-                    className="border rounded px-2 py-1 text-sm"
-                  >
-                    <option value="ACTIVE">ACTIVE</option>
-                    <option value="BANNED">BANNED</option>
-                  </select>
-                )}</td>
-              </tr>
-            ))}
+                        <select
+                          value={user.userStatus}
+                          onChange={(e) => handleStatusChange(user, e.target.value)}
+                          className="border rounded px-2 py-1.5 text-sm w-[100px] h-[32px]"
+                        >
+                          <option value="ACTIVE">ACTIVE</option>
+                          <option value="BANNED">BANNED</option>
+                        </select>
+                      )}
+                    </td>
+                    </tr>
+                  ))}
             </tbody>
           </table>
-          </div>
+        </div>
         <div className="flex-shrink-0 mt-auto pt-4 pb-8">
           <div className="flex items-center justify-center space-x-8">
             <button

--- a/NangPaGo-admin/src/pages/Users.jsx
+++ b/NangPaGo-admin/src/pages/Users.jsx
@@ -9,7 +9,7 @@ export default function Users() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
   const [actionType, setActionType] = useState("");
-  const [sortField, setSortField] = useState("id");
+  const [sortField, setSortField] = useState("ID");
 
   const toggleSort = (field) => {
     if (sortField === field) {
@@ -48,7 +48,8 @@ export default function Users() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await getUserList(currentPage, isAscending, sortField);
+        const sortType = `${sortField}_${isAscending ? 'ASC' : 'DESC'}`;
+        const response = await getUserList(currentPage, sortType);
         setUsers(response.data.content);
         setTotalPages(response.data.totalPages);
       } catch (error) {
@@ -57,7 +58,7 @@ export default function Users() {
     };
     fetchData();
   }, [currentPage, isAscending, sortField]);
-
+  
   return (
     <div className="p-6">
       <h2 className="text-2xl font-semibold text-gray-900 mb-6">사용자 관리</h2>
@@ -81,12 +82,12 @@ export default function Users() {
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">이메일</th>
               <th 
                 className="px-4 py-3 text-left text-sm font-semibold border-b cursor-pointer group"
-                onClick={() => toggleSort('nickname')}
+                onClick={() => toggleSort('NICKNAME')}
               >
                 <div className="flex items-center">
                   닉네임
                   <span className="ml-1">
-                    {sortField === 'nickname' ? (
+                    {sortField === 'NICKNAME' ? (
                       isAscending ? (
                         <svg className="w-4 h-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 15l7-7 7 7"/>
@@ -109,12 +110,12 @@ export default function Users() {
               <th className="px-4 py-3 text-left text-sm font-semibold border-b">가입 경로</th>
               <th 
                 className="px-4 py-3 text-left text-sm font-semibold border-b cursor-pointer group"
-                onClick={() => toggleSort('id')}
+                onClick={() => toggleSort('ID')}
               >
                 <div className="flex items-center">
                   가입일
                   <span className="ml-1">
-                    {sortField === 'id' ? (
+                    {sortField === 'ID' ? (
                       isAscending ? (
                         <svg className="w-4 h-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 15l7-7 7 7"/>

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
@@ -7,7 +7,6 @@ import com.mars.admin.domain.user.sort.SortType;
 import com.mars.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
@@ -3,7 +3,7 @@ package com.mars.admin.domain.user.controller;
 import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.service.UserService;
-import com.mars.admin.domain.user.sort.SortType;
+import com.mars.admin.domain.user.sort.UserListSortType;
 import com.mars.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,7 +30,7 @@ public class UserController {
 
     @GetMapping
     public ResponseDto<Page<UserDetailResponseDto>> userList(@RequestParam(defaultValue = "0") int pageNo,
-                                                             @RequestParam(defaultValue = "ID_ASC") SortType sort) {
+                                                             @RequestParam(defaultValue = "ID_ASC") UserListSortType sort) {
         return ResponseDto.of(userService.getUserList(pageNo, sort), "");
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
@@ -1,12 +1,15 @@
 package com.mars.admin.domain.user.controller;
 
-import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.service.UserService;
 import com.mars.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -16,19 +19,12 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping
-    public ResponseDto<Page<UserDetailResponseDto>> userList(@RequestParam(defaultValue = "0") int page) {
-        return ResponseDto.of(userService.getUserList(page), "");
-    }
-
-    @PutMapping("/ban")
-    public ResponseDto<UserBanResponseDto> banUser(@RequestParam long userId) {
-        UserBanResponseDto userBanResponseDto = userService.banUser(userId);
-        return ResponseDto.of(userBanResponseDto, "");
-    }
-
-    @PutMapping("/unban")
-    public ResponseDto<UserBanResponseDto> unbanUser(@RequestParam long userId) {
-        UserBanResponseDto userBanResponseDto = userService.unbanUser(userId);
-        return ResponseDto.of(userBanResponseDto, "");
+    public ResponseDto<Page<UserDetailResponseDto>> userList(@RequestParam(defaultValue = "0") int page,
+                                                             @RequestParam(defaultValue = "true") boolean asc,
+                                                             @RequestParam(defaultValue = "id") String sortName) {
+        if (asc) {
+            return ResponseDto.of(userService.getUserList(page, Sort.Direction.ASC, sortName), "");
+        }
+        return ResponseDto.of(userService.getUserList(page, Sort.Direction.DESC, sortName), "");
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/controller/UserController.java
@@ -1,15 +1,14 @@
 package com.mars.admin.domain.user.controller;
 
+import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.service.UserService;
+import com.mars.admin.domain.user.sort.SortType;
 import com.mars.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -18,13 +17,21 @@ public class UserController {
 
     private final UserService userService;
 
+    @PutMapping("/ban")
+    public ResponseDto<UserBanResponseDto> banUser(@RequestParam long userId) {
+        UserBanResponseDto userBanResponseDto = userService.banUser(userId);
+        return ResponseDto.of(userBanResponseDto, "");
+    }
+
+    @PutMapping("/unban")
+    public ResponseDto<UserBanResponseDto> unbanUser(@RequestParam long userId) {
+        UserBanResponseDto userBanResponseDto = userService.unbanUser(userId);
+        return ResponseDto.of(userBanResponseDto, "");
+    }
+
     @GetMapping
-    public ResponseDto<Page<UserDetailResponseDto>> userList(@RequestParam(defaultValue = "0") int page,
-                                                             @RequestParam(defaultValue = "true") boolean asc,
-                                                             @RequestParam(defaultValue = "id") String sortName) {
-        if (asc) {
-            return ResponseDto.of(userService.getUserList(page, Sort.Direction.ASC, sortName), "");
-        }
-        return ResponseDto.of(userService.getUserList(page, Sort.Direction.DESC, sortName), "");
+    public ResponseDto<Page<UserDetailResponseDto>> userList(@RequestParam(defaultValue = "0") int pageNo,
+                                                             @RequestParam(defaultValue = "ID_ASC") SortType sort) {
+        return ResponseDto.of(userService.getUserList(pageNo, sort), "");
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/repository/UserRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/repository/UserRepository.java
@@ -13,4 +13,22 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.role <> 'ROLE_ADMIN'")
     Page<User> findByRoleNotAdmin(Pageable pageable);
+
+    @Query("""
+        SELECT u FROM User u 
+        WHERE u.role <> 'ROLE_ADMIN' 
+        ORDER BY 
+            FUNCTION('REGEXP_REPLACE', u.nickname, '[0-9]+$', ''),
+            CAST(FUNCTION('REGEXP_SUBSTR', u.nickname, '[0-9]+$') AS int) ASC
+    """)
+    Page<User> findByRoleNotAdminOrderByNicknameAsc(Pageable pageable);
+
+    @Query("""
+        SELECT u FROM User u 
+        WHERE u.role <> 'ROLE_ADMIN' 
+        ORDER BY 
+            FUNCTION('REGEXP_REPLACE', u.nickname, '[0-9]+$', '') DESC,
+            CAST(FUNCTION('REGEXP_SUBSTR', u.nickname, '[0-9]+$') AS int) DESC
+    """)
+    Page<User> findByRoleNotAdminOrderByNicknameDesc(Pageable pageable);
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.mars.admin.domain.user.service;
 import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.repository.UserRepository;
-import com.mars.admin.domain.user.sort.SortType;
+import com.mars.admin.domain.user.sort.UserListSortType;
 import com.mars.common.dto.user.UserResponseDto;
 import com.mars.common.enums.user.UserStatus;
 import com.mars.common.model.user.User;
@@ -29,7 +29,7 @@ public class UserService {
         return UserResponseDto.from(userRepository.findById(userId).orElseThrow(NOT_FOUND_USER::of));
     }
 
-    public Page<UserDetailResponseDto> getUserList(int pageNo, SortType sort) {
+    public Page<UserDetailResponseDto> getUserList(int pageNo, UserListSortType sort) {
         Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE);
 
         return switch (sort) {

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
@@ -30,8 +30,20 @@ public class UserService {
     }
 
     public Page<UserDetailResponseDto> getUserList(int pageNo, SortType sort) {
-        Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE, Sort.by(sort.getDirection(), sort.getField()));
-        return userRepository.findByRoleNotAdmin(pageable).map(UserDetailResponseDto::from);
+        Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE);
+
+        return switch (sort) {
+            case NICKNAME_ASC ->
+                userRepository.findByRoleNotAdminOrderByNicknameAsc(pageable)
+                    .map(UserDetailResponseDto::from);
+            case NICKNAME_DESC ->
+                userRepository.findByRoleNotAdminOrderByNicknameDesc(pageable)
+                    .map(UserDetailResponseDto::from);
+            default ->
+                userRepository.findByRoleNotAdmin(
+                    PageRequest.of(pageNo, PAGE_SIZE, Sort.by(sort.getDirection(), sort.getField()))
+                ).map(UserDetailResponseDto::from);
+        };
     }
 
     @Transactional

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
@@ -10,10 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.mars.common.exception.NPGExceptionType.*;
+import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_USER;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -27,8 +28,8 @@ public class UserService {
         return UserResponseDto.from(userRepository.findById(userId).orElseThrow(NOT_FOUND_USER::of));
     }
 
-    public Page<UserDetailResponseDto> getUserList(int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+    public Page<UserDetailResponseDto> getUserList(int page, Sort.Direction sort, String sortName) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(sort, sortName));
         return userRepository.findByRoleNotAdmin(pageable).map(UserDetailResponseDto::from);
     }
 

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.mars.admin.domain.user.service;
 import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.repository.UserRepository;
+import com.mars.admin.domain.user.sort.SortType;
 import com.mars.common.dto.user.UserResponseDto;
 import com.mars.common.enums.user.UserStatus;
 import com.mars.common.model.user.User;
@@ -28,8 +29,8 @@ public class UserService {
         return UserResponseDto.from(userRepository.findById(userId).orElseThrow(NOT_FOUND_USER::of));
     }
 
-    public Page<UserDetailResponseDto> getUserList(int page, Sort.Direction sort, String sortName) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(sort, sortName));
+    public Page<UserDetailResponseDto> getUserList(int pageNo, SortType sort) {
+        Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE, Sort.by(sort.getDirection(), sort.getField()));
         return userRepository.findByRoleNotAdmin(pageable).map(UserDetailResponseDto::from);
     }
 

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/SortType.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/SortType.java
@@ -1,0 +1,26 @@
+package com.mars.admin.domain.user.sort;
+
+import org.springframework.data.domain.Sort;
+
+    public enum SortType {
+        ID_ASC("id", Sort.Direction.ASC),
+        ID_DESC("id", Sort.Direction.DESC),
+        NICKNAME_ASC("nickname", Sort.Direction.ASC),
+        NICKNAME_DESC("nickname", Sort.Direction.DESC);
+
+        private final String field;
+        private final Sort.Direction direction;
+
+        SortType(String field, Sort.Direction direction) {
+            this.field = field;
+            this.direction = direction;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public Sort.Direction getDirection() {
+            return direction;
+        }
+    }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/SortType.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/SortType.java
@@ -2,25 +2,25 @@ package com.mars.admin.domain.user.sort;
 
 import org.springframework.data.domain.Sort;
 
-    public enum SortType {
-        ID_ASC("id", Sort.Direction.ASC),
-        ID_DESC("id", Sort.Direction.DESC),
-        NICKNAME_ASC("nickname", Sort.Direction.ASC),
-        NICKNAME_DESC("nickname", Sort.Direction.DESC);
+public enum SortType {
+    ID_ASC("id", Sort.Direction.ASC),
+    ID_DESC("id", Sort.Direction.DESC),
+    NICKNAME_ASC("nickname", Sort.Direction.ASC),
+    NICKNAME_DESC("nickname", Sort.Direction.DESC);
 
-        private final String field;
-        private final Sort.Direction direction;
+    private final String field;
+    private final Sort.Direction direction;
 
-        SortType(String field, Sort.Direction direction) {
-            this.field = field;
-            this.direction = direction;
-        }
-
-        public String getField() {
-            return field;
-        }
-
-        public Sort.Direction getDirection() {
-            return direction;
-        }
+    SortType(String field, Sort.Direction direction) {
+        this.field = field;
+        this.direction = direction;
     }
+
+    public String getField() {
+        return field;
+    }
+
+    public Sort.Direction getDirection() {
+        return direction;
+    }
+}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/UserListSortType.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/UserListSortType.java
@@ -1,7 +1,9 @@
 package com.mars.admin.domain.user.sort;
 
+import lombok.Getter;
 import org.springframework.data.domain.Sort;
 
+@Getter
 public enum UserListSortType {
     ID_ASC("id", Sort.Direction.ASC),
     ID_DESC("id", Sort.Direction.DESC),
@@ -16,11 +18,4 @@ public enum UserListSortType {
         this.direction = direction;
     }
 
-    public String getField() {
-        return field;
-    }
-
-    public Sort.Direction getDirection() {
-        return direction;
-    }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/UserListSortType.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/sort/UserListSortType.java
@@ -2,7 +2,7 @@ package com.mars.admin.domain.user.sort;
 
 import org.springframework.data.domain.Sort;
 
-public enum SortType {
+public enum UserListSortType {
     ID_ASC("id", Sort.Direction.ASC),
     ID_DESC("id", Sort.Direction.DESC),
     NICKNAME_ASC("nickname", Sort.Direction.ASC),
@@ -11,7 +11,7 @@ public enum SortType {
     private final String field;
     private final Sort.Direction direction;
 
-    SortType(String field, Sort.Direction direction) {
+    UserListSortType(String field, Sort.Direction direction) {
         this.field = field;
         this.direction = direction;
     }

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 class UserServiceTest extends IntegrationTestSupport {
 
@@ -74,7 +75,7 @@ class UserServiceTest extends IntegrationTestSupport {
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> result = userService.getUserList(0);
+        Page<UserDetailResponseDto> result = userService.getUserList(0, Sort.Direction.ASC, "id");
 
         // then
         assertThat(result.getContent().size()).isEqualTo(10);

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
@@ -42,6 +42,15 @@ class UserServiceTest extends IntegrationTestSupport {
             .build();
     }
 
+    private User createUserWithNickname(String email, String nickname) {
+        return User.builder()
+                .email(email)
+                .nickname(nickname)
+                .userStatus(UserStatus.ACTIVE)
+                .role("ROLE_USER")
+                .build();
+    }
+
     @DisplayName("사용자 정보를 조회할 수 있다.")
     @Test
     void getCurrentUser() {
@@ -81,6 +90,82 @@ class UserServiceTest extends IntegrationTestSupport {
         assertThat(result.getContent().size()).isEqualTo(10);
         assertThat(result.getTotalElements()).isEqualTo(15);
         assertThat(result.getTotalPages()).isEqualTo(2);
+    }
+
+    @DisplayName("사용자 목록을 Id를 기준으로 내림차순 정렬할 수 있다.")
+    @Test
+    void getUserListSortedByIdDesc() {
+        // given
+        List<User> users = IntStream.range(0, 15)
+                .mapToObj(i -> createUser("test" + i + "@example.com"))
+                .collect(Collectors.toList());
+        userRepository.saveAll(users);
+
+        // when
+        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, Sort.Direction.DESC, "id");
+        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, Sort.Direction.DESC, "id");
+
+        // then
+        assertThat(firstPage.getContent().get(0).id()).isGreaterThan(secondPage.getContent().get(4).id());
+    }
+
+    @DisplayName("사용자 목록을 Id를 기준으로 오름차순 정렬할 수 있다.")
+    @Test
+    void getUserListSortedByIdAsc() {
+        // given
+        List<User> users = IntStream.range(0, 15)
+                .mapToObj(i -> createUser("test" + i + "@example.com"))
+                .collect(Collectors.toList());
+        userRepository.saveAll(users);
+
+        // when
+        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, Sort.Direction.ASC, "id");
+        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, Sort.Direction.ASC, "id");
+
+        // then
+        assertThat(firstPage.getContent().get(0).id()).isLessThan(secondPage.getContent().get(4).id());
+    }
+
+    @DisplayName("사용자 목록을 닉네임을 기준으로 내림차순 정렬할 수 있다.")
+    @Test
+    void getUserListSortedByNicknameDesc() {
+        // given
+        List<User> users = IntStream.range(0, 15)
+                .mapToObj(i -> createUserWithNickname("test" + i + "@example.com"
+                        , "nickname" + i))
+                .collect(Collectors.toList());
+        userRepository.saveAll(users);
+
+        // when
+        Page<UserDetailResponseDto> firstPage = userService
+                .getUserList(0, Sort.Direction.DESC, "nickname");
+        Page<UserDetailResponseDto> secondPage = userService
+                .getUserList(1, Sort.Direction.DESC, "nickname");
+
+        // then
+        assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname9");
+        assertThat(secondPage.getContent().get(4).nickname()).isEqualTo("nickname0");
+    }
+
+    @DisplayName("사용자 목록을 닉네임을 기준으로 오름차순 정렬할 수 있다.")
+    @Test
+    void getUserListSortedByNicknameAsc() {
+        // given
+        List<User> users = IntStream.range(0, 15)
+                .mapToObj(i -> createUserWithNickname("test" + i + "@example.com"
+                        , "nickname" + i))
+                .collect(Collectors.toList());
+        userRepository.saveAll(users);
+
+        // when
+        Page<UserDetailResponseDto> firstPage = userService
+                .getUserList(0, Sort.Direction.ASC, "nickname");
+        Page<UserDetailResponseDto> secondPage = userService
+                .getUserList(1, Sort.Direction.ASC, "nickname");
+
+        // then
+        assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname0");
+        assertThat(secondPage.getContent().get(4).nickname()).isEqualTo("nickname9");
     }
 
     @DisplayName("사용자를 차단할 수 있다.")

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
@@ -143,7 +143,7 @@ class UserServiceTest extends IntegrationTestSupport {
                 .getUserList(1, SortType.NICKNAME_DESC);
 
         // then
-        assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname9");
+        assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname14");
         assertThat(secondPage.getContent().get(4).nickname()).isEqualTo("nickname0");
     }
 
@@ -165,7 +165,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname0");
-        assertThat(secondPage.getContent().get(4).nickname()).isEqualTo("nickname9");
+        assertThat(secondPage.getContent().get(4).nickname()).isEqualTo("nickname14");
     }
 
     @DisplayName("사용자를 차단할 수 있다.")

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.repository.UserRepository;
-import com.mars.admin.domain.user.sort.SortType;
+import com.mars.admin.domain.user.sort.UserListSortType;
 import com.mars.admin.support.IntegrationTestSupport;
 import com.mars.common.dto.user.UserResponseDto;
 import com.mars.common.enums.user.UserStatus;
@@ -34,28 +34,21 @@ class UserServiceTest extends IntegrationTestSupport {
         userRepository.deleteAllInBatch();
     }
 
-    private User createUser(String email) {
+    private User createUser(String email, String nickname) {
         return User.builder()
             .email(email)
+            .nickname(nickname)
             .userStatus(UserStatus.ACTIVE)
             .role("ROLE_USER")
             .build();
     }
 
-    private User createUserWithNickname(String email, String nickname) {
-        return User.builder()
-                .email(email)
-                .nickname(nickname)
-                .userStatus(UserStatus.ACTIVE)
-                .role("ROLE_USER")
-                .build();
-    }
 
     @DisplayName("사용자 정보를 조회할 수 있다.")
     @Test
     void getCurrentUser() {
         // given
-        User user = createUser("test@example.com");
+        User user = createUser("test@example.com", "nickname");
         userRepository.save(user);
 
         // when
@@ -79,12 +72,12 @@ class UserServiceTest extends IntegrationTestSupport {
     void getUserList() {
         // given
         List<User> users = IntStream.range(0, 15)
-            .mapToObj(i -> createUser("test" + i + "@example.com"))
+            .mapToObj(i -> createUser("test" + i + "@example.com", "nickname"))
             .collect(Collectors.toList());
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> result = userService.getUserList(0, SortType.ID_ASC);
+        Page<UserDetailResponseDto> result = userService.getUserList(0, UserListSortType.ID_ASC);
 
         // then
         assertThat(result.getContent().size()).isEqualTo(10);
@@ -97,13 +90,13 @@ class UserServiceTest extends IntegrationTestSupport {
     void getUserListSortedByIdDesc() {
         // given
         List<User> users = IntStream.range(0, 15)
-                .mapToObj(i -> createUser("test" + i + "@example.com"))
+                .mapToObj(i -> createUser("test" + i + "@example.com", "nickname"))
                 .collect(Collectors.toList());
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, SortType.ID_DESC);
-        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, SortType.ID_DESC);
+        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, UserListSortType.ID_DESC);
+        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, UserListSortType.ID_DESC);
 
         // then
         assertThat(firstPage.getContent().get(0).id()).isGreaterThan(secondPage.getContent().get(4).id());
@@ -114,13 +107,13 @@ class UserServiceTest extends IntegrationTestSupport {
     void getUserListSortedByIdAsc() {
         // given
         List<User> users = IntStream.range(0, 15)
-                .mapToObj(i -> createUser("test" + i + "@example.com"))
+                .mapToObj(i -> createUser("test" + i + "@example.com", "nickname"))
                 .collect(Collectors.toList());
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, SortType.ID_ASC);
-        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, SortType.ID_ASC);
+        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, UserListSortType.ID_ASC);
+        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, UserListSortType.ID_ASC);
 
         // then
         assertThat(firstPage.getContent().get(0).id()).isLessThan(secondPage.getContent().get(4).id());
@@ -131,16 +124,16 @@ class UserServiceTest extends IntegrationTestSupport {
     void getUserListSortedByNicknameDesc() {
         // given
         List<User> users = IntStream.range(0, 15)
-                .mapToObj(i -> createUserWithNickname("test" + i + "@example.com"
+                .mapToObj(i -> createUser("test" + i + "@example.com"
                         , "nickname" + i))
                 .collect(Collectors.toList());
         userRepository.saveAll(users);
 
         // when
         Page<UserDetailResponseDto> firstPage = userService
-                .getUserList(0, SortType.NICKNAME_DESC);
+                .getUserList(0, UserListSortType.NICKNAME_DESC);
         Page<UserDetailResponseDto> secondPage = userService
-                .getUserList(1, SortType.NICKNAME_DESC);
+                .getUserList(1, UserListSortType.NICKNAME_DESC);
 
         // then
         assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname14");
@@ -152,16 +145,16 @@ class UserServiceTest extends IntegrationTestSupport {
     void getUserListSortedByNicknameAsc() {
         // given
         List<User> users = IntStream.range(0, 15)
-                .mapToObj(i -> createUserWithNickname("test" + i + "@example.com"
+                .mapToObj(i -> createUser("test" + i + "@example.com"
                         , "nickname" + i))
                 .collect(Collectors.toList());
         userRepository.saveAll(users);
 
         // when
         Page<UserDetailResponseDto> firstPage = userService
-                .getUserList(0, SortType.NICKNAME_ASC);
+                .getUserList(0, UserListSortType.NICKNAME_ASC);
         Page<UserDetailResponseDto> secondPage = userService
-                .getUserList(1, SortType.NICKNAME_ASC);
+                .getUserList(1, UserListSortType.NICKNAME_ASC);
 
         // then
         assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname0");
@@ -172,7 +165,7 @@ class UserServiceTest extends IntegrationTestSupport {
     @Test
     void banUser() {
         // given
-        User user = createUser("test@example.com");
+        User user = createUser("test@example.com", "nickname");
         userRepository.save(user);
 
         // when
@@ -190,7 +183,7 @@ class UserServiceTest extends IntegrationTestSupport {
     @Test
     void unbanUser() {
         // given
-        User user = createUser("test@example.com");
+        User user = createUser("test@example.com", "nickname");
         user.updateUserStatus(UserStatus.BANNED);
         userRepository.save(user);
 

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Sort;
 
 class UserServiceTest extends IntegrationTestSupport {
 

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import com.mars.admin.domain.user.dto.UserBanResponseDto;
 import com.mars.admin.domain.user.dto.UserDetailResponseDto;
 import com.mars.admin.domain.user.repository.UserRepository;
+import com.mars.admin.domain.user.sort.SortType;
 import com.mars.admin.support.IntegrationTestSupport;
 import com.mars.common.dto.user.UserResponseDto;
 import com.mars.common.enums.user.UserStatus;
@@ -84,7 +85,7 @@ class UserServiceTest extends IntegrationTestSupport {
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> result = userService.getUserList(0, Sort.Direction.ASC, "id");
+        Page<UserDetailResponseDto> result = userService.getUserList(0, SortType.ID_ASC);
 
         // then
         assertThat(result.getContent().size()).isEqualTo(10);
@@ -102,8 +103,8 @@ class UserServiceTest extends IntegrationTestSupport {
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, Sort.Direction.DESC, "id");
-        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, Sort.Direction.DESC, "id");
+        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, SortType.ID_DESC);
+        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, SortType.ID_DESC);
 
         // then
         assertThat(firstPage.getContent().get(0).id()).isGreaterThan(secondPage.getContent().get(4).id());
@@ -119,8 +120,8 @@ class UserServiceTest extends IntegrationTestSupport {
         userRepository.saveAll(users);
 
         // when
-        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, Sort.Direction.ASC, "id");
-        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, Sort.Direction.ASC, "id");
+        Page<UserDetailResponseDto> firstPage = userService.getUserList(0, SortType.ID_ASC);
+        Page<UserDetailResponseDto> secondPage = userService.getUserList(1, SortType.ID_ASC);
 
         // then
         assertThat(firstPage.getContent().get(0).id()).isLessThan(secondPage.getContent().get(4).id());
@@ -138,9 +139,9 @@ class UserServiceTest extends IntegrationTestSupport {
 
         // when
         Page<UserDetailResponseDto> firstPage = userService
-                .getUserList(0, Sort.Direction.DESC, "nickname");
+                .getUserList(0, SortType.NICKNAME_DESC);
         Page<UserDetailResponseDto> secondPage = userService
-                .getUserList(1, Sort.Direction.DESC, "nickname");
+                .getUserList(1, SortType.NICKNAME_DESC);
 
         // then
         assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname9");
@@ -159,9 +160,9 @@ class UserServiceTest extends IntegrationTestSupport {
 
         // when
         Page<UserDetailResponseDto> firstPage = userService
-                .getUserList(0, Sort.Direction.ASC, "nickname");
+                .getUserList(0, SortType.NICKNAME_ASC);
         Page<UserDetailResponseDto> secondPage = userService
-                .getUserList(1, Sort.Direction.ASC, "nickname");
+                .getUserList(1, SortType.NICKNAME_ASC);
 
         // then
         assertThat(firstPage.getContent().get(0).nickname()).isEqualTo("nickname0");


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- **닉네임**과 **생성일자**를 기준으로 **정렬**기능을 추가했습니다.
    - `auto Increment`를 사용하여 가입기준 순서대로 들어가기 때문에 `DB` `index`설정이 되어있는 `id`로 생성일자를 정렬했습니다.
    - 정렬을 하면서 닉네임 및 이메일 등의 길이 차이로 인해 위치가 고정이 안되어 있기에,
     위치를 반응형에 맞게 %로 고정 및 일정 너비 이상일 시 `...`으로 표시 되도록 하였습니다.

> - **기본적으로 생성일자 내림차순으로 정렬됩니다.**
![image](https://github.com/user-attachments/assets/234523ae-142a-493b-9a4a-8d79b40133be)

> - **사진과 같이 정렬 가능한 부분의 표시를 두었으며, 한번 더 클릭 시 오름차순 <-> 내림차순 으로 바뀝니다.**
![image](https://github.com/user-attachments/assets/af01a6b2-d75c-49b5-b218-aa801d859712)
![image](https://github.com/user-attachments/assets/fec67aa5-901b-48a0-ae16-0e76fec34433)
![image](https://github.com/user-attachments/assets/85ea7b79-28a5-4800-821a-eaff5079104c)




- **생성일자**와 **닉네임**으로 정렬하는 것에 대한 **테스트 코드를 추가**했습니다.
    - 테스트 코드를 작성하면서 정렬될 때, `nickname` 1부터 12까지 생성한다고 할때,
    1, 11, 12, 2, 3 이런식으로 정렬 됩니다.
    - 이 부분이 실제 조회했을 때 탈퇴한 유저의 닉네임이 이런식으로 정렬이 됩니다.
    - `Comparator`를 사용하는 방법은 데이터를 전부 로드한 뒤 정렬해야 되어서 적용하지 않았으며,
    `substr`로 해당 부분이 숫자인지를 확인하여 정렬하는 방법은
    숫자가 자릿수가 계속 늘어나는 상황이나 다른 닉네임이 섞이는 등의 문제로 올바른 정렬이 되지 않았습니다.
    

- 우선 테스트 코드 또한 1, 11, 12, 2, 3 이런식으로 정렬 되어 확인하고 있습니다.

- 이 부분이 문제가 될 경우가 거의 탈퇴한 회원{숫자} 일텐데 `id`를 기준으로 조회하면 정상적으로 조회가 되니,
이 부분을 보류한채 필터 기능을 추가할 때, 탈퇴한 유저만 볼 경우 닉네임으로 정렬을 제외하면 되지않을까 합니다.

   
    
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).