### PR TITLE
[NPG-206] 레시피 즐겨찾기 비동기로 개선

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/rabbitmq/RabbitMQConfig.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/rabbitmq/RabbitMQConfig.java
@@ -7,6 +7,7 @@ import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,21 +17,32 @@ public class RabbitMQConfig {
 
     @Value("${RABBITMQ_CONSUMER_NAME}")
     private String developer;
-    public static final String LIKE_ROUTING_KEY = "recipe.like.*";
+    public static final String RECIPE_LIKE_ROUTING_KEY = "recipe.like.*";
+    public static final String RECIPE_FAVORITE_ROUTING_KEY = "recipe.favorite.*";
 
     @Bean
     public TopicExchange topicExchange() {
         return new TopicExchange(this.getExchangeName());
     }
 
-    @Bean
-    public Queue likeQueue() {
+    @Bean(name = "recipeLikeQueue")
+    public Queue recipeLikeQueue() {
         return new Queue(this.getLikeQueueName());
     }
 
+    @Bean(name = "recipeFavoriteQueue")
+    public Queue recipeFavoriteQueue() {
+        return new Queue(this.getFavoriteQueueName());
+    }
+
     @Bean
-    public Binding binding(Queue queue, TopicExchange exchange) {
-        return BindingBuilder.bind(queue).to(exchange).with(LIKE_ROUTING_KEY);
+    public Binding recipeLikeBinding(@Qualifier("recipeLikeQueue") Queue recipeLikeQueue, TopicExchange exchange) {
+        return BindingBuilder.bind(recipeLikeQueue).to(exchange).with(RECIPE_LIKE_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding recipeFavoriteBinding(@Qualifier("recipeFavoriteQueue") Queue recipeFavoriteQueue, TopicExchange exchange) {
+        return BindingBuilder.bind(recipeFavoriteQueue).to(exchange).with(RECIPE_FAVORITE_ROUTING_KEY);
     }
 
     @Bean
@@ -46,7 +58,11 @@ public class RabbitMQConfig {
     }
 
     private String getLikeQueueName() {
-        return "like-notification-queue-" + developer;
+        return "recipe-like-notification-queue-" + developer;
+    }
+
+    private String getFavoriteQueueName() {
+        return "recipe-favorite-notification-queue-" + developer;
     }
 
     private String getExchangeName() {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/controller/RecipeFavoriteController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/controller/RecipeFavoriteController.java
@@ -1,5 +1,6 @@
 package com.mars.app.domain.favorite.recipe.controller;
 
+import com.mars.app.domain.favorite.recipe.message.RecipeFavoriteMessagePublisher;
 import com.mars.common.dto.PageDto;
 import com.mars.common.dto.ResponseDto;
 import com.mars.app.aop.auth.AuthenticatedUser;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class RecipeFavoriteController {
 
     private final RecipeFavoriteService recipeFavoriteService;
+    private final RecipeFavoriteMessagePublisher recipeFavoriteMessagePublisher;
 
     @Operation(summary = "즐겨찾기 상태 확인")
     @GetMapping("/{id}/favorite/status")
@@ -35,7 +37,7 @@ public class RecipeFavoriteController {
     @PostMapping("/{id}/favorite/toggle")
     public ResponseDto<RecipeFavoriteResponseDto> toggleFavorite(@PathVariable("id") Long id) {
         Long userId = AuthenticationHolder.getCurrentUserId();
-        return ResponseDto.of(recipeFavoriteService.toggleFavorite(id, userId));
+        return ResponseDto.of(recipeFavoriteMessagePublisher.toggleFavorite(id, userId));
     }
 
     @Operation(summary = "즐겨찾기 목록 조회")

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/dto/RecipeFavoriteMessageDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/dto/RecipeFavoriteMessageDto.java
@@ -1,0 +1,16 @@
+package com.mars.app.domain.favorite.recipe.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RecipeFavoriteMessageDto(
+    Long recipeId,
+    Long userId
+) {
+    public static RecipeFavoriteMessageDto of(Long recipeId, Long userId) {
+        return RecipeFavoriteMessageDto.builder()
+            .recipeId(recipeId)
+            .userId(userId)
+            .build();
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/dto/RecipeFavoriteResponseDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/dto/RecipeFavoriteResponseDto.java
@@ -4,13 +4,11 @@ import lombok.Builder;
 
 @Builder
 public record RecipeFavoriteResponseDto(
-    Long recipeId,
-    boolean favorited
+    Long recipeId
 ) {
-    public static RecipeFavoriteResponseDto of(Long recipeId, boolean favorited) {
+    public static RecipeFavoriteResponseDto of(Long recipeId) {
         return RecipeFavoriteResponseDto.builder()
             .recipeId(recipeId)
-            .favorited(favorited)
             .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumer.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumer.java
@@ -1,0 +1,52 @@
+package com.mars.app.domain.favorite.recipe.message;
+
+import com.mars.app.domain.comment.recipe.repository.RecipeCommentRepository;
+import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteMessageDto;
+import com.mars.app.domain.favorite.recipe.repository.RecipeFavoriteRepository;
+import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
+import com.mars.app.domain.recipe.repository.RecipeRepository;
+import com.mars.app.domain.user.repository.UserRepository;
+import com.mars.common.exception.NPGExceptionType;
+import com.mars.common.model.favorite.recipe.RecipeFavorite;
+import com.mars.common.model.recipe.Recipe;
+import com.mars.common.model.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class RecipeFavoriteMessageConsumer {
+
+    private final RecipeFavoriteRepository recipeFavoriteRepository;
+    private final RecipeRepository recipeRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    @RabbitListener(queues = "#{recipeFavoriteQueue.name}")
+    public void processRecipeFavoriteMessage(RecipeFavoriteMessageDto recipeFavoriteMessageDto) {
+        toggleFavoriteStatus(recipeFavoriteMessageDto.userId(), recipeFavoriteMessageDto.recipeId());
+    }
+
+    private void toggleFavoriteStatus(Long userId, Long recipeId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of);
+        Recipe recipe = recipeRepository.findById(recipeId)
+            .orElseThrow(NPGExceptionType.NOT_FOUND_RECIPE::of);
+
+        recipeFavoriteRepository.findByUserAndRecipe(user, recipe)
+            .map(this::removeFavorite)
+            .orElseGet(() -> addFavorite(user, recipe));
+    }
+
+    private boolean addFavorite(User user, Recipe recipe) {
+        recipeFavoriteRepository.save(RecipeFavorite.of(user, recipe));
+        return true;
+    }
+
+    private boolean removeFavorite(RecipeFavorite recipeFavorite) {
+        recipeFavoriteRepository.delete(recipeFavorite);
+        return false;
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumer.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumer.java
@@ -1,9 +1,7 @@
 package com.mars.app.domain.favorite.recipe.message;
 
-import com.mars.app.domain.comment.recipe.repository.RecipeCommentRepository;
 import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteMessageDto;
 import com.mars.app.domain.favorite.recipe.repository.RecipeFavoriteRepository;
-import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
 import com.mars.app.domain.recipe.repository.RecipeRepository;
 import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.common.exception.NPGExceptionType;

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessagePublisher.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessagePublisher.java
@@ -1,0 +1,28 @@
+package com.mars.app.domain.favorite.recipe.message;
+
+import static com.mars.app.config.rabbitmq.RabbitMQConfig.*;
+
+import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteMessageDto;
+import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RecipeFavoriteMessagePublisher {
+
+    private final TopicExchange topicExchange;
+    private final RabbitTemplate rabbitTemplate;
+
+    public RecipeFavoriteResponseDto toggleFavorite(Long recipeId, Long userId) {
+        sendFavoriteMessage(recipeId, userId);
+        return RecipeFavoriteResponseDto.of(recipeId);
+    }
+
+    private void sendFavoriteMessage(Long recipeId, Long userId) {
+        RecipeFavoriteMessageDto recipeFavoriteMessageDto = RecipeFavoriteMessageDto.of(recipeId, userId);
+        rabbitTemplate.convertAndSend(topicExchange.getName(), RECIPE_FAVORITE_ROUTING_KEY, recipeFavoriteMessageDto);
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/repository/RecipeFavoriteRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/repository/RecipeFavoriteRepository.java
@@ -1,7 +1,5 @@
 package com.mars.app.domain.favorite.recipe.repository;
 
-import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
-
 import com.mars.common.model.favorite.recipe.RecipeFavorite;
 import com.mars.common.model.recipe.Recipe;
 import com.mars.common.model.user.User;
@@ -9,7 +7,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,7 +14,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, Long> {
 
-    @Lock(PESSIMISTIC_WRITE)
     Optional<RecipeFavorite> findByUserAndRecipe(User user, Recipe recipe);
 
     @Query("SELECT rf FROM RecipeFavorite rf WHERE rf.user = :user")

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteService.java
@@ -25,18 +25,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecipeFavoriteService {
 
     private final RecipeFavoriteRepository recipeFavoriteRepository;
-    private final RecipeRepository recipeRepository;
     private final UserRepository userRepository;
     private final RecipeLikeRepository recipeLikeRepository;
     private final RecipeCommentRepository recipeCommentRepository;
 
-    @Transactional
-    public RecipeFavoriteResponseDto toggleFavorite(Long recipeId, Long userId) {
-        boolean isFavorite = toggleFavoriteStatus(userId, recipeId);
-        return RecipeFavoriteResponseDto.of(recipeId, isFavorite);
-    }
-
-    @Transactional
     public boolean isFavorite(Long recipeId, Long userId) {
         return recipeFavoriteRepository.findByUserIdAndRecipeId(userId, recipeId).isPresent();
     }
@@ -56,24 +48,4 @@ public class RecipeFavoriteService {
         );
     }
 
-    private boolean toggleFavoriteStatus(Long userId, Long recipeId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(NPGExceptionType.NOT_FOUND_USER::of);
-        Recipe recipe = recipeRepository.findById(recipeId)
-            .orElseThrow(NPGExceptionType.NOT_FOUND_RECIPE::of);
-
-        return recipeFavoriteRepository.findByUserAndRecipe(user, recipe)
-            .map(this::removeFavorite)
-            .orElseGet(() -> addFavorite(user, recipe));
-    }
-
-    private boolean addFavorite(User user, Recipe recipe) {
-        recipeFavoriteRepository.save(RecipeFavorite.of(user, recipe));
-        return true;
-    }
-
-    private boolean removeFavorite(RecipeFavorite recipeFavorite) {
-        recipeFavoriteRepository.delete(recipeFavorite);
-        return false;
-    }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/controller/RecipeController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/controller/RecipeController.java
@@ -1,6 +1,6 @@
 package com.mars.app.domain.recipe.controller;
 
-import com.mars.app.domain.recipe.event.RecipeLikeNotificationPublisher;
+import com.mars.app.domain.recipe.message.RecipeLikeMessagePublisher;
 import com.mars.app.domain.recipe.event.RecipeLikeSseService;
 import com.mars.common.dto.ResponseDto;
 import com.mars.app.aop.auth.AuthenticatedUser;
@@ -32,9 +32,9 @@ public class RecipeController {
 
     private final RecipeService recipeService;
     private final RecipeLikeService recipeLikeService;
-    private final RecipeLikeNotificationPublisher recipeLikeNotificationPublisher;
     private final RecipeEsService recipeEsService;
     private final RecipeEsSynchronizerService recipeEsSynchronizerService;
+    private final RecipeLikeMessagePublisher recipeLikeMessagePublisher;
     private final RecipeLikeSseService recipeLikeSseService;
 
     @GetMapping("/{id}")
@@ -53,7 +53,7 @@ public class RecipeController {
     @PostMapping("/{id}/like/toggle")
     public ResponseDto<RecipeLikeResponseDto> toggleRecipeLike(@PathVariable Long id) {
         Long userId = AuthenticationHolder.getCurrentUserId();
-        return ResponseDto.of(recipeLikeNotificationPublisher.toggleLike(id, userId));
+        return ResponseDto.of(recipeLikeMessagePublisher.toggleLike(id, userId));
     }
 
     @GetMapping("/{id}/like/count")

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumer.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumer.java
@@ -28,8 +28,8 @@ public class RecipeLikeMessageConsumer {
     private final ApplicationEventPublisher sseEventPublisher;
 
     @Transactional
-    @RabbitListener(queues = "#{@likeQueue.name}")
-    public void processLikeEvent(RecipeLikeMessageDto recipeLikeMessageDto) {
+    @RabbitListener(queues = "#{@recipeLikeQueue.name}")
+    public void processLikeMessage(RecipeLikeMessageDto recipeLikeMessageDto) {
         toggleLikeStatus(recipeLikeMessageDto.recipeId(), recipeLikeMessageDto.userId());
         publishRecipeLikeEvent(recipeLikeMessageDto);
     }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumer.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumer.java
@@ -1,9 +1,10 @@
-package com.mars.app.domain.recipe.event;
+package com.mars.app.domain.recipe.message;
 
 import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_RECIPE;
 import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_USER;
 
 import com.mars.app.domain.recipe.dto.RecipeLikeMessageDto;
+import com.mars.app.domain.recipe.event.RecipeLikeEvent;
 import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
 import com.mars.app.domain.recipe.repository.RecipeRepository;
 import com.mars.app.domain.user.repository.UserRepository;
@@ -18,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-public class RecipeLikeNotificationConsumer {
+public class RecipeLikeMessageConsumer {
 
     private final RecipeLikeRepository recipeLikeRepository;
     private final RecipeRepository recipeRepository;

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisher.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisher.java
@@ -1,4 +1,4 @@
-package com.mars.app.domain.recipe.event;
+package com.mars.app.domain.recipe.message;
 
 import static com.mars.app.config.rabbitmq.RabbitMQConfig.LIKE_ROUTING_KEY;
 
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class RecipeLikeNotificationPublisher {
+public class RecipeLikeMessagePublisher {
 
     private final TopicExchange topicExchange;
     private final RabbitTemplate rabbitTemplate;

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisher.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisher.java
@@ -1,6 +1,6 @@
 package com.mars.app.domain.recipe.message;
 
-import static com.mars.app.config.rabbitmq.RabbitMQConfig.LIKE_ROUTING_KEY;
+import static com.mars.app.config.rabbitmq.RabbitMQConfig.RECIPE_LIKE_ROUTING_KEY;
 
 import com.mars.app.domain.recipe.dto.RecipeLikeMessageDto;
 import com.mars.app.domain.recipe.dto.RecipeLikeResponseDto;
@@ -25,6 +25,6 @@ public class RecipeLikeMessagePublisher {
     private void sendLikeNotification(Long recipeId, Long userId) {
         // Message 전송 to RabbitMQ
         RecipeLikeMessageDto recipeLikeMessageDto = RecipeLikeMessageDto.of(recipeId, userId);
-        rabbitTemplate.convertAndSend(topicExchange.getName(), LIKE_ROUTING_KEY, recipeLikeMessageDto);
+        rabbitTemplate.convertAndSend(topicExchange.getName(), RECIPE_LIKE_ROUTING_KEY, recipeLikeMessageDto);
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumerTest.java
@@ -1,0 +1,123 @@
+package com.mars.app.domain.favorite.recipe.message;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteMessageDto;
+import com.mars.app.domain.favorite.recipe.repository.RecipeFavoriteRepository;
+import com.mars.app.domain.recipe.repository.RecipeRepository;
+import com.mars.app.domain.user.repository.UserRepository;
+import com.mars.app.support.IntegrationTestSupport;
+import com.mars.common.exception.NPGException;
+import com.mars.common.model.favorite.recipe.RecipeFavorite;
+import com.mars.common.model.recipe.Recipe;
+import com.mars.common.model.user.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RecipeFavoriteMessageConsumerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RecipeFavoriteRepository recipeFavoriteRepository;
+    @Autowired
+    private RecipeRepository recipeRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RecipeFavoriteMessageConsumer recipeFavoriteMessageConsumer;
+
+    @AfterEach
+    void tearDown() {
+        recipeFavoriteRepository.deleteAllInBatch();
+        recipeRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("레시피 즐겨찾기 메시지를 처리하고 즐겨찾기를 추가할 수 있다.")
+    @Test
+    void processRecipeFavoriteMessageAdd() {
+        // given
+        User user = createUser("test@nangpago.com");
+        Recipe recipe = createRecipe("테스트 레시피");
+
+        userRepository.save(user);
+        recipeRepository.save(recipe);
+
+        RecipeFavoriteMessageDto messageDto = RecipeFavoriteMessageDto.of(recipe.getId(), user.getId());
+
+        // when
+        recipeFavoriteMessageConsumer.processRecipeFavoriteMessage(messageDto);
+
+        // then
+        assertThat(recipeFavoriteRepository.findByUserAndRecipe(user, recipe))
+            .isPresent();
+    }
+
+    @DisplayName("레시피 즐겨찾기 메시지를 처리하고 즐겨찾기를 취소할 수 있다.")
+    @Test
+    void processRecipeFavoriteMessageCancel() {
+        // given
+        User user = createUser("test@nangpago.com");
+        Recipe recipe = createRecipe("테스트 레시피");
+
+        userRepository.save(user);
+        recipeRepository.save(recipe);
+
+        RecipeFavorite recipeFavorite = RecipeFavorite.of(user, recipe);
+        recipeFavoriteRepository.save(recipeFavorite);
+
+        RecipeFavoriteMessageDto messageDto = RecipeFavoriteMessageDto.of(recipe.getId(), user.getId());
+
+        // when
+        recipeFavoriteMessageConsumer.processRecipeFavoriteMessage(messageDto);
+
+        // then
+        assertThat(recipeFavoriteRepository.findByUserAndRecipe(user, recipe))
+            .isEmpty();
+    }
+
+    @DisplayName("존재하지 않는 사용자의 즐겨찾기 메시지를 처리할 때 예외가 발생한다.")
+    @Test
+    void processFavoriteMessageWithInvalidUser() {
+        // given
+        Recipe recipe = createRecipe("테스트 레시피");
+        recipeRepository.save(recipe);
+
+        RecipeFavoriteMessageDto messageDto = RecipeFavoriteMessageDto.of(recipe.getId(), 9999L);
+
+        // when & then
+        assertThatThrownBy(() -> recipeFavoriteMessageConsumer.processRecipeFavoriteMessage(messageDto))
+            .isInstanceOf(NPGException.class)
+            .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
+    @DisplayName("존재하지 않는 레시피의 즐겨찾기 메시지를 처리할 때 예외가 발생한다.")
+    @Test
+    void processFavoriteMessageWithInvalidRecipe() {
+        // given
+        User user = createUser("test@nangpago.com");
+        userRepository.save(user);
+
+        RecipeFavoriteMessageDto messageDto = RecipeFavoriteMessageDto.of(9999L, user.getId());
+
+        // when & then
+        assertThatThrownBy(() -> recipeFavoriteMessageConsumer.processRecipeFavoriteMessage(messageDto))
+            .isInstanceOf(NPGException.class)
+            .hasMessage("레시피를 찾을 수 없습니다.");
+    }
+
+    private User createUser(String email) {
+        return User.builder()
+            .email(email)
+            .build();
+    }
+
+    private Recipe createRecipe(String name) {
+        return Recipe.builder()
+            .name(name)
+            .build();
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessagePublisherTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessagePublisherTest.java
@@ -1,0 +1,78 @@
+package com.mars.app.domain.favorite.recipe.message;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mars.app.config.rabbitmq.RabbitMQConfig;
+import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteMessageDto;
+import com.mars.app.domain.favorite.recipe.dto.RecipeFavoriteResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class RecipeFavoriteMessagePublisherTest {
+
+    @Mock
+    private TopicExchange topicExchange;
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private RecipeFavoriteMessagePublisher recipeFavoriteMessagePublisher;
+
+    @DisplayName("레시피 즐겨찾기 토글 이벤트를 발행할 수 있다.")
+    @Test
+    void toggleFavorite() {
+        // given
+        Long recipeId = 1L;
+        Long userId = 1L;
+        String exchangeName = "test-exchange";
+
+        when(topicExchange.getName()).thenReturn(exchangeName);
+
+        // when
+        RecipeFavoriteResponseDto result = recipeFavoriteMessagePublisher.toggleFavorite(recipeId, userId);
+
+        // then
+        verify(rabbitTemplate).convertAndSend(
+            eq(exchangeName),
+            eq(RabbitMQConfig.RECIPE_FAVORITE_ROUTING_KEY),
+            any(RecipeFavoriteMessageDto.class)
+        );
+
+        assertThat(result)
+            .extracting("recipeId")
+            .isEqualTo(recipeId);
+    }
+
+    @DisplayName("레시피 즐겨찾기 메시지 발행 시 올바른 DTO가 전송되는지 확인한다.")
+    @Test
+    void verifyMessageDto() {
+        // given
+        Long recipeId = 1L;
+        Long userId = 1L;
+        String exchangeName = "test-exchange";
+
+        when(topicExchange.getName()).thenReturn(exchangeName);
+
+        // when
+        recipeFavoriteMessagePublisher.toggleFavorite(recipeId, userId);
+
+        // then
+        verify(rabbitTemplate).convertAndSend(
+            eq(exchangeName),
+            eq(RabbitMQConfig.RECIPE_FAVORITE_ROUTING_KEY),
+            eq(RecipeFavoriteMessageDto.of(recipeId, userId))
+        );
+    }
+
+}

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
@@ -40,48 +40,6 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
         userRepository.deleteAllInBatch();
     }
 
-    @DisplayName("레시피를 즐겨찾기 할 수 있다.")
-    @Test
-    void addRecipeFavorite() {
-        // given
-        User user = createUser("dummy@nangpago.com");
-        Recipe recipe = createRecipe("파스타");
-
-        userRepository.save(user);
-        recipeRepository.save(recipe);
-
-        // when
-        RecipeFavoriteResponseDto favoriteResponseDto = recipeFavoriteService.toggleFavorite(recipe.getId(),
-            user.getId());
-
-        // then
-        assertThat(favoriteResponseDto)
-            .extracting("favorited", "recipeId")
-            .containsExactly(true, recipe.getId());
-    }
-
-    @DisplayName("등록된 레시피 즐겨찾기를 취소한다.")
-    @Test
-    void cancelRecipeFavorite() {
-        // given
-        User user = createUser("dummy@nangpago.com");
-        Recipe recipe = createRecipe("파스타");
-        RecipeFavorite recipeFavorite = createRecipeFavorite(user, recipe);
-
-        userRepository.save(user);
-        recipeRepository.save(recipe);
-        recipeFavoriteRepository.save(recipeFavorite);
-
-        // when
-        RecipeFavoriteResponseDto favoriteResponseDto = recipeFavoriteService.toggleFavorite(recipe.getId(),
-            user.getId());
-
-        // then
-        assertThat(favoriteResponseDto)
-            .extracting("favorited", "recipeId")
-            .containsExactly(false, recipe.getId());
-    }
-
     @DisplayName("즐겨찾기한 레시피의 즐겨찾기 상태는 true 이다.")
     @Test
     void isFavoriteByUser() {
@@ -145,37 +103,6 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
             .extracting(PageDto::getTotalPages, PageDto::getTotalItems)
             .containsExactly(1, 4L);
         assertThat(recipeFavorites.getContent().get(1).name()).isEqualTo("순대국밥");
-    }
-
-    @DisplayName("사용자를 찾을 수 없을 때 예외를 발생시킬 수 있다.")
-    @Test
-    void NotCorrectUserException() {
-        // given
-        Long nonExistUserId = 9999L;
-
-        Recipe recipe = createRecipe("파스타");
-        recipeRepository.save(recipe);
-
-        // when, then
-        assertThatThrownBy(() -> recipeFavoriteService.toggleFavorite(recipe.getId(), nonExistUserId))
-            .isInstanceOf(NPGException.class)
-            .hasMessage("사용자를 찾을 수 없습니다.");
-    }
-
-    @DisplayName("레시피를 찾을 수 없을 때 예외를 발생시킬 수 있다.")
-    @Test
-    void NotFoundRecipeException() {
-        // given
-        User user = createUser("dummy@nangpago.com");
-
-        userRepository.save(user);
-
-        Long recipeId = 1L;
-
-        // when, then
-        assertThatThrownBy(() -> recipeFavoriteService.toggleFavorite(recipeId, user.getId()))
-            .isInstanceOf(NPGException.class)
-            .hasMessage("레시피를 찾을 수 없습니다.");
     }
 
     private User createUser(String email) {

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
@@ -51,18 +51,6 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
         userRepository.deleteAllInBatch();
     }
 
-    private User createUser(String email) {
-        return User.builder()
-            .email(email)
-            .build();
-    }
-
-    private Recipe createRecipe(String name) {
-        return Recipe.builder()
-            .name(name)
-            .build();
-    }
-
     @DisplayName("레시피 좋아요 메시지를 처리하고 좋아요를 추가할 수 있다.")
     @Test
     void processLikeMessageAdd() {
@@ -152,5 +140,17 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeMessage(messageDto))
             .isInstanceOf(NPGException.class)
             .hasMessage("레시피를 찾을 수 없습니다.");
+    }
+
+    private User createUser(String email) {
+        return User.builder()
+            .email(email)
+            .build();
+    }
+
+    private Recipe createRecipe(String name) {
+        return Recipe.builder()
+            .name(name)
+            .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
@@ -1,4 +1,4 @@
-package com.mars.app.domain.recipe.event;
+package com.mars.app.domain.recipe.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.argThat;
 
 import com.mars.app.domain.recipe.dto.RecipeLikeMessageDto;
+import com.mars.app.domain.recipe.event.RecipeLikeEvent;
 import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
 import com.mars.app.domain.recipe.repository.RecipeRepository;
 import com.mars.app.domain.user.repository.UserRepository;
@@ -23,7 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
-class RecipeLikeNotificationConsumerTest extends IntegrationTestSupport {
+class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
 
     @Autowired
     private RecipeLikeRepository recipeLikeRepository;
@@ -36,11 +37,11 @@ class RecipeLikeNotificationConsumerTest extends IntegrationTestSupport {
     private ApplicationEventPublisher sseEventPublisher;
 
     @Autowired
-    private RecipeLikeNotificationConsumer recipeLikeNotificationConsumer;
+    private RecipeLikeMessageConsumer recipeLikeMessageConsumer;
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(recipeLikeNotificationConsumer, "sseEventPublisher", sseEventPublisher);
+        ReflectionTestUtils.setField(recipeLikeMessageConsumer, "sseEventPublisher", sseEventPublisher);
     }
 
     @AfterEach
@@ -75,7 +76,7 @@ class RecipeLikeNotificationConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getId());
 
         // when
-        recipeLikeNotificationConsumer.processLikeEvent(messageDto);
+        recipeLikeMessageConsumer.processLikeEvent(messageDto);
 
         // then
         verify(sseEventPublisher).publishEvent(
@@ -107,7 +108,7 @@ class RecipeLikeNotificationConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getId());
 
         // when
-        recipeLikeNotificationConsumer.processLikeEvent(messageDto);
+        recipeLikeMessageConsumer.processLikeEvent(messageDto);
 
         // then
         verify(sseEventPublisher).publishEvent(
@@ -133,7 +134,7 @@ class RecipeLikeNotificationConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), 9999L);
 
         // when & then
-        assertThatThrownBy(() -> recipeLikeNotificationConsumer.processLikeEvent(messageDto))
+        assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeEvent(messageDto))
             .isInstanceOf(NPGException.class)
             .hasMessage("사용자를 찾을 수 없습니다.");
     }
@@ -148,7 +149,7 @@ class RecipeLikeNotificationConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(999L, user.getId());
 
         // when & then
-        assertThatThrownBy(() -> recipeLikeNotificationConsumer.processLikeEvent(messageDto))
+        assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeEvent(messageDto))
             .isInstanceOf(NPGException.class)
             .hasMessage("레시피를 찾을 수 없습니다.");
     }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
@@ -65,7 +65,7 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
 
     @DisplayName("레시피 좋아요 메시지를 처리하고 좋아요를 추가할 수 있다.")
     @Test
-    void processLikeEventAdd() {
+    void processLikeMessageAdd() {
         // given
         User user = createUser("test@nangpago.com");
         Recipe recipe = createRecipe("테스트 레시피");
@@ -76,7 +76,7 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getId());
 
         // when
-        recipeLikeMessageConsumer.processLikeEvent(messageDto);
+        recipeLikeMessageConsumer.processLikeMessage(messageDto);
 
         // then
         verify(sseEventPublisher).publishEvent(
@@ -94,7 +94,7 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
 
     @DisplayName("레시피 좋아요 메시지를 처리하고 좋아요를 취소할 수 있다.")
     @Test
-    void processLikeEventRemove() {
+    void processLikeMessageRemove() {
         // given
         User user = createUser("test@nangpago.com");
         Recipe recipe = createRecipe("테스트 레시피");
@@ -108,7 +108,7 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), user.getId());
 
         // when
-        recipeLikeMessageConsumer.processLikeEvent(messageDto);
+        recipeLikeMessageConsumer.processLikeMessage(messageDto);
 
         // then
         verify(sseEventPublisher).publishEvent(
@@ -126,7 +126,7 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
 
     @DisplayName("존재하지 않는 사용자의 좋아요 메시지를 처리할 때 예외가 발생한다.")
     @Test
-    void processLikeEventWithInvalidUser() {
+    void processLikeMessageWithInvalidUser() {
         // given
         Recipe recipe = createRecipe("테스트 레시피");
         recipeRepository.save(recipe);
@@ -134,14 +134,14 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(recipe.getId(), 9999L);
 
         // when & then
-        assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeEvent(messageDto))
+        assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeMessage(messageDto))
             .isInstanceOf(NPGException.class)
             .hasMessage("사용자를 찾을 수 없습니다.");
     }
 
     @DisplayName("존재하지 않는 레시피의 좋아요 메시지를 처리할 때 예외가 발생한다.")
     @Test
-    void processLikeEventWithInvalidRecipe() {
+    void processLikeMessageWithInvalidRecipe() {
         // given
         User user = createUser("test@nangpago.com");
         userRepository.save(user);
@@ -149,7 +149,7 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
         RecipeLikeMessageDto messageDto = RecipeLikeMessageDto.of(999L, user.getId());
 
         // when & then
-        assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeEvent(messageDto))
+        assertThatThrownBy(() -> recipeLikeMessageConsumer.processLikeMessage(messageDto))
             .isInstanceOf(NPGException.class)
             .hasMessage("레시피를 찾을 수 없습니다.");
     }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisherTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisherTest.java
@@ -45,7 +45,7 @@ class RecipeLikeMessagePublisherTest {
         // then
         verify(rabbitTemplate).convertAndSend(
             eq(exchangeName),
-            eq(RabbitMQConfig.LIKE_ROUTING_KEY),
+            eq(RabbitMQConfig.RECIPE_LIKE_ROUTING_KEY),
             any(RecipeLikeMessageDto.class)
         );
 
@@ -70,7 +70,7 @@ class RecipeLikeMessagePublisherTest {
         // then
         verify(rabbitTemplate).convertAndSend(
             eq(exchangeName),
-            eq(RabbitMQConfig.LIKE_ROUTING_KEY),
+            eq(RabbitMQConfig.RECIPE_LIKE_ROUTING_KEY),
             eq(RecipeLikeMessageDto.of(recipeId, userId))
         );
     }

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisherTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessagePublisherTest.java
@@ -1,4 +1,4 @@
-package com.mars.app.domain.recipe.event;
+package com.mars.app.domain.recipe.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,7 +19,7 @@ import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
 @ExtendWith(MockitoExtension.class)
-class RecipeLikeNotificationPublisherTest {
+class RecipeLikeMessagePublisherTest {
 
     @Mock
     private TopicExchange topicExchange;
@@ -27,7 +27,7 @@ class RecipeLikeNotificationPublisherTest {
     private RabbitTemplate rabbitTemplate;
 
     @InjectMocks
-    private RecipeLikeNotificationPublisher recipeLikeNotificationPublisher;
+    private RecipeLikeMessagePublisher recipeLikeMessagePublisher;
 
     @DisplayName("레시피 좋아요 토글 이벤트를 발행할 수 있다.")
     @Test
@@ -40,7 +40,7 @@ class RecipeLikeNotificationPublisherTest {
         when(topicExchange.getName()).thenReturn(exchangeName);
 
         // when
-        RecipeLikeResponseDto result = recipeLikeNotificationPublisher.toggleLike(recipeId, userId);
+        RecipeLikeResponseDto result = recipeLikeMessagePublisher.toggleLike(recipeId, userId);
 
         // then
         verify(rabbitTemplate).convertAndSend(
@@ -65,7 +65,7 @@ class RecipeLikeNotificationPublisherTest {
         when(topicExchange.getName()).thenReturn(exchangeName);
 
         // when
-        recipeLikeNotificationPublisher.toggleLike(recipeId, userId);
+        recipeLikeMessagePublisher.toggleLike(recipeId, userId);
 
         // then
         verify(rabbitTemplate).convertAndSend(

--- a/NangPaGo-client/src/api/postStatus.js
+++ b/NangPaGo-client/src/api/postStatus.js
@@ -1,5 +1,4 @@
 import axiosInstance from './axiosInstance';
-import { PAGE_INDEX, PAGE_SIZE } from '../common/constants/pagination'
 
 export const getLikeCount = async (post) => {
   try {

--- a/NangPaGo-client/src/hooks/usePostStatus.js
+++ b/NangPaGo-client/src/hooks/usePostStatus.js
@@ -120,9 +120,16 @@ const usePostStatus = (postType, postId, isLoggedIn) => {
     }
 
     try {
-      const { favorited } = await toggleFavorite(post);
-      setIsStarActive(favorited);
+      // 낙관적 업데이트: 즉시 UI 반영
+      setIsStarActive(prev => !prev);
+
+      // 서버에 토글 요청만 보내고 응답은 무시
+      await toggleFavorite(post);
+      
+      // 서버 요청이 성공하면 낙관적 업데이트를 유지
     } catch (error) {
+      // 에러 발생 시 원래 상태로 복구
+      setIsStarActive(prev => !prev);
       console.error('즐겨찾기 상태 변경 오류:', error);
     }
   };


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 레시피 즐겨찾기 기능을 MQ 기반 비동기 처리 방식으로 개선하고, 쿼리의 Lock을 제거합니다.

## PR 유형

- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [x] 파일 혹은 폴더명 수정

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).