### PR TITLE
[NO-ISSUE] 테스트 코드 데이터 클렌징을 `@Transactional` 을 사용하도록 변경

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/dto/RecipeResponseDto.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/recipe/dto/RecipeResponseDto.java
@@ -3,6 +3,7 @@ package com.mars.app.domain.recipe.dto;
 import com.mars.common.model.recipe.Manual;
 import com.mars.common.model.recipe.ManualImage;
 import com.mars.common.model.recipe.Recipe;
+import java.util.Collections;
 import lombok.Builder;
 
 import java.util.List;
@@ -39,8 +40,12 @@ public record RecipeResponseDto(
             .natrium(recipe.getNatrium())
             .mainIngredient(recipe.getMainIngredient())
             .mainImage(recipe.getMainImage())
-            .manuals(recipe.getManuals().stream().map(ManualDto::from).collect(Collectors.toList()))
-            .manualImages(recipe.getManualImages().stream().map(ManualImageDto::from).collect(Collectors.toList()))
+            .manuals(recipe.getManuals() != null ?
+                recipe.getManuals().stream().map(ManualDto::from).collect(Collectors.toList()) :
+                Collections.emptyList())
+            .manualImages(recipe.getManualImages() != null ?
+                recipe.getManualImages().stream().map(ManualImageDto::from).collect(Collectors.toList()) :
+                Collections.emptyList())
             .build();
     }
 

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/aop/auth/AuthenticationAspectTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/aop/auth/AuthenticationAspectTest.java
@@ -9,13 +9,14 @@ import com.mars.app.service.TestService;
 import com.mars.app.support.IntegrationTestSupport;
 import com.mars.common.exception.NPGException;
 import com.mars.common.model.user.User;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class AuthenticationAspectTest extends IntegrationTestSupport {
 
     @Autowired
@@ -26,11 +27,6 @@ class AuthenticationAspectTest extends IntegrationTestSupport {
 
     @Autowired
     private TestService testService;
-
-    @AfterEach
-    void tearDown() {
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("인증된 사용자는 @AuthenticatedUser 어노테이션이 붙은 메서드를 실행할 수 있다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/auth/service/OAuth2ProviderTokenServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/auth/service/OAuth2ProviderTokenServiceTest.java
@@ -22,13 +22,14 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class OAuth2ProviderTokenServiceTest extends IntegrationTestSupport {
 
     @MockitoBean
@@ -45,12 +46,6 @@ class OAuth2ProviderTokenServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private OAuth2ProviderTokenService oauth2ProviderTokenService;
-
-    @AfterEach
-    void tearDown() {
-        oauthProviderTokenRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("새로운 OAuth2 Provider 토큰을 저장할 수 있다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/auth/service/TokenServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/auth/service/TokenServiceTest.java
@@ -13,13 +13,14 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class TokenServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -31,11 +32,6 @@ class TokenServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private TokenService tokenService;
-
-    @AfterEach
-    void tearDown() {
-        refreshTokenRepository.deleteAllInBatch();
-    }
 
     @DisplayName("유효한 Refresh Token으로 Access Token을 재발급할 수 있다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/community/service/CommunityCommentServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/community/service/CommunityCommentServiceTest.java
@@ -16,11 +16,12 @@ import com.mars.common.model.community.Community;
 import com.mars.common.model.user.User;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class CommunityCommentServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -32,13 +33,6 @@ class CommunityCommentServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private CommunityCommentService communityCommentService;
-
-    @AfterEach
-    void tearDown() {
-        communityCommentRepository.deleteAllInBatch();
-        communityRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("게시글의 모든 댓글을 조회할 수 있다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/recipe/service/RecipeCommentServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/comment/recipe/service/RecipeCommentServiceTest.java
@@ -16,11 +16,12 @@ import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.support.IntegrationTestSupport;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RecipeCommentServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -32,13 +33,6 @@ class RecipeCommentServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RecipeCommentService recipeCommentService;
-
-    @AfterEach
-    void tearDown() {
-        recipeCommentRepository.deleteAllInBatch();
-        recipeRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("레시피의 모든 댓글을 조회한다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityLikeServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityLikeServiceTest.java
@@ -6,16 +6,17 @@ import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.support.IntegrationTestSupport;
 import com.mars.common.model.community.Community;
 import com.mars.common.model.community.CommunityLike;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import com.mars.common.model.user.User;
+import org.springframework.transaction.annotation.Transactional;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Transactional
 class CommunityLikeServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -29,14 +30,6 @@ class CommunityLikeServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private CommunityLikeService communityLikeService;
-
-
-    @AfterEach
-    void tearDown() {
-        communityLikeRepository.deleteAll();
-        communityRepository.deleteAll();
-        userRepository.deleteAll();
-    }
 
     private User createUser(String email) {
         return User.builder()

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/community/service/CommunityServiceTest.java
@@ -11,15 +11,16 @@ import com.mars.app.support.IntegrationTestSupport;
 import com.mars.common.dto.page.PageDto;
 import com.mars.common.model.community.Community;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.mars.common.model.user.User;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Transactional
 class CommunityServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -39,14 +40,6 @@ class CommunityServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private FirebaseStorageService firebaseStorageService;
-
-    @AfterEach
-    void tearDown() {
-        communityLikeRepository.deleteAllInBatch();
-        communityCommentRepository.deleteAllInBatch();
-        communityRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     private User createUser(String nickname) {
         return User.builder()

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/message/RecipeFavoriteMessageConsumerTest.java
@@ -11,12 +11,12 @@ import com.mars.common.exception.NPGException;
 import com.mars.common.model.favorite.recipe.RecipeFavorite;
 import com.mars.common.model.recipe.Recipe;
 import com.mars.common.model.user.User;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RecipeFavoriteMessageConsumerTest extends IntegrationTestSupport {
 
     @Autowired
@@ -28,13 +28,6 @@ class RecipeFavoriteMessageConsumerTest extends IntegrationTestSupport {
 
     @Autowired
     private RecipeFavoriteMessageConsumer recipeFavoriteMessageConsumer;
-
-    @AfterEach
-    void tearDown() {
-        recipeFavoriteRepository.deleteAllInBatch();
-        recipeRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("레시피 즐겨찾기 메시지를 처리하고 즐겨찾기를 추가할 수 있다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/favorite/recipe/service/RecipeFavoriteServiceTest.java
@@ -1,7 +1,6 @@
 package com.mars.app.domain.favorite.recipe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mars.common.dto.page.PageDto;
 import com.mars.common.dto.page.PageRequestVO;
@@ -15,11 +14,12 @@ import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.support.IntegrationTestSupport;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RecipeFavoriteServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -31,13 +31,6 @@ class RecipeFavoriteServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RecipeFavoriteService recipeFavoriteService;
-
-    @AfterEach
-    void tearDown() {
-        recipeFavoriteRepository.deleteAllInBatch();
-        recipeRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("즐겨찾기한 레시피의 즐겨찾기 상태는 true 이다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/message/RecipeLikeMessageConsumerTest.java
@@ -15,7 +15,6 @@ import com.mars.common.exception.NPGException;
 import com.mars.common.model.recipe.Recipe;
 import com.mars.common.model.recipe.RecipeLike;
 import com.mars.common.model.user.User;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,9 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
 
     @Autowired
@@ -42,13 +43,6 @@ class RecipeLikeMessageConsumerTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(recipeLikeMessageConsumer, "sseEventPublisher", sseEventPublisher);
-    }
-
-    @AfterEach
-    void tearDown() {
-        recipeLikeRepository.deleteAllInBatch();
-        recipeRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
     }
 
     @DisplayName("레시피 좋아요 메시지를 처리하고 좋아요를 추가할 수 있다.")

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/service/RecipeLikeServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/recipe/service/RecipeLikeServiceTest.java
@@ -1,10 +1,7 @@
 package com.mars.app.domain.recipe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.mars.common.exception.NPGException;
-import com.mars.app.domain.recipe.dto.RecipeLikeResponseDto;
 import com.mars.common.model.recipe.Recipe;
 import com.mars.common.model.recipe.RecipeLike;
 import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
@@ -12,13 +9,13 @@ import com.mars.app.domain.recipe.repository.RecipeRepository;
 import com.mars.common.model.user.User;
 import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.support.IntegrationTestSupport;
-import jakarta.transaction.Transactional;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RecipeLikeServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -30,13 +27,6 @@ class RecipeLikeServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RecipeLikeService recipeLikeService;
-
-    @AfterEach
-    void tearDown() {
-        recipeLikeRepository.deleteAllInBatch();
-        recipeRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("좋아요를 누른 레시피는 좋아요 상태가 true 이다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/refrigerator/service/RefrigeratorServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/refrigerator/service/RefrigeratorServiceTest.java
@@ -2,7 +2,6 @@ package com.mars.app.domain.refrigerator.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.in;
 
 import com.mars.common.exception.NPGException;
 import com.mars.common.model.ingredient.Ingredient;
@@ -15,11 +14,11 @@ import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.support.IntegrationTestSupport;
 import jakarta.transaction.Transactional;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Transactional
 class RefrigeratorServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -33,13 +32,6 @@ class RefrigeratorServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RefrigeratorService refrigeratorService;
-
-    @AfterEach
-    void tearDown() {
-        refrigeratorRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-        ingredientRepository.deleteAllInBatch();
-    }
 
     @Transactional
     @DisplayName("냉장고 속 재료 전체 리스트를 조회할 수 있다.")

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user/service/UserServiceTest.java
@@ -25,12 +25,13 @@ import com.mars.app.domain.comment.recipe.repository.RecipeCommentRepository;
 import com.mars.app.domain.favorite.recipe.repository.RecipeFavoriteRepository;
 import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
 import com.mars.app.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Transactional
 class UserServiceTest extends IntegrationTestSupport {
 
     @Autowired
@@ -46,14 +47,6 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private UserService userService;
-
-    @AfterEach
-    void tearDown() {
-        recipeLikeRepository.deleteAllInBatch();
-        recipeFavoriteRepository.deleteAllInBatch();
-        recipeCommentRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
 
     @DisplayName("현재 사용자 정보를 조회할 수 있다.")
     @Test

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user/service/UserServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user/service/UserServiceTest.java
@@ -26,6 +26,7 @@ import com.mars.app.domain.favorite.recipe.repository.RecipeFavoriteRepository;
 import com.mars.app.domain.recipe.repository.RecipeLikeRepository;
 import com.mars.app.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -299,6 +300,8 @@ class UserServiceTest extends IntegrationTestSupport {
             .calorie(100)
             .category("레시피 카테고리")
             .cookingMethod("조리방법")
+            .manuals(new ArrayList<>())
+            .manualImages(new ArrayList<>())
             .build();
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 기존 tearDown - deleteAllInBatch() 방식은 동시에 여러 사람이 테스트를 시도하면 데이터가 겹치는 문제가 발생함.
- `@Transactional` 로 변경하여, 실제로 DB에 데이터가 insert 되지 않도록 변경.

## PR 유형

- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).