### PR TITLE
[NPG-217] 브라우저에서 지원하는 기본 폰트로 변경

### DIFF
--- a/NangPaGo-client/src/components/button/SocialLoginButton.jsx
+++ b/NangPaGo-client/src/components/button/SocialLoginButton.jsx
@@ -14,7 +14,7 @@ function SocialLoginButton({ provider, onClick }) {
         className="h-7 w-7 mr-3"
       />
 
-      <div className="w-3/5">
+      <div className="w-4/5">
         <span className={`text-base font-medium ${currentStyle.text}`}>
           {currentStyle.label}
         </span>

--- a/NangPaGo-client/src/globals.css
+++ b/NangPaGo-client/src/globals.css
@@ -2,14 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face {
-  font-family: 'Moneygraphy';
-  font-style: normal;
-  font-weight: 400;
-  src: url(/fonts/Moneygraphy-Rounded.woff) format('woff'),
-  url(/fonts/Moneygraphy-Rounded.ttf) format('truetype');
-}
-
 body {
   @apply min-h-screen text-text-900 font-sans;
 }

--- a/NangPaGo-client/tailwind.config.js
+++ b/NangPaGo-client/tailwind.config.js
@@ -21,7 +21,7 @@ export default {
         },
       },
       fontFamily: {
-        sans: ['Moneygraphy', '맑은 고딕', 'sans-serif'],
+        sans: ['맑은 고딕', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## 개요
- 브라우저에서 지원하는 기본 폰트로 변경
	- 현재 사용 중인 Moneygraphy는 다양한 브라우저에 대응하기 어렵기 때문에 @font-face 삭제함

- 기본 폰트로 변경하면, 로그인페이지 - 소셜로그인버튼이 이렇게 보임..
	- text와 label 영역의 너비를 60%(w-3/5) -> 80%(w-4/5)로 수정
<img width="266" alt="KakaoTalk_20250203" src="https://github.com/user-attachments/assets/3c1d6c17-708f-4166-82e8-79cba491d9db" /> 


## PR 유형

- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경 사항

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).