### PR TITLE
[NPG-225] 좋아요 및 즐겨찾기 아이콘 UI 변경

### DIFF
--- a/NangPaGo-client/src/components/button/RecipeButton.jsx
+++ b/NangPaGo-client/src/components/button/RecipeButton.jsx
@@ -1,4 +1,5 @@
-import { FaHeart, FaStar } from 'react-icons/fa';
+import { FaHeart, FaRegHeart, FaStar, FaRegStar  } from 'react-icons/fa';
+import { IoHeartOutline, IoHeart } from 'react-icons/io5';
 
 function RecipeButton({
   isHeartActive,
@@ -16,7 +17,11 @@ function RecipeButton({
         }`}
         onClick={toggleHeart}
       >
-        <FaHeart className="text-2xl" />
+        {isHeartActive ? (
+          <FaHeart className="text-2xl" />
+        ) : (
+          <FaRegHeart className="text-2xl" />
+        )}
         {likeCount !== null && (
           <span className="text-sm ml-1">{likeCount}</span>
         )}
@@ -27,7 +32,11 @@ function RecipeButton({
         }`}
         onClick={toggleStar}
       >
-        <FaStar className="text-2xl" />
+        {isStarActive ? (
+          <FaStar className="text-2xl" />
+        ) : (
+          <FaRegStar className="text-2xl" />
+        )}
       </button>
     </div>
   );

--- a/NangPaGo-client/src/components/community/Community.jsx
+++ b/NangPaGo-client/src/components/community/Community.jsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FaHeart } from 'react-icons/fa';
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
 import ToggleButton from '../button/ToggleButton';
 import { IMAGE_STYLES } from '../../common/styles/Image';
 import { deleteCommunity } from '../../api/community';
@@ -87,7 +87,11 @@ function Community({ post, data: community, isLoggedIn }) {
           }`}
           onClick={toggleHeart}
         >
-          <FaHeart className="text-2xl" />
+          {isHeartActive ? (
+            <FaHeart className="text-2xl" />
+          ) : (
+            <FaRegHeart className="text-2xl" />
+          )}
           <span className="text-sm ml-1">{likeCount}</span>
         </button>
       </div>


### PR DESCRIPTION
## 개요
- 수정 전: 좋아요와 즐겨찾기 아이콘이 OFF일 경우, 회색으로 채워져 있음
- 수정 후: OFF일 때, 테두리만 남기고 속이 비어있는 아이콘으로 변경(FaRegHeart, FaRegStar 추가)

![스크린샷 2025-02-04 175024](https://github.com/user-attachments/assets/df727060-bdcf-41dc-99f4-52a12d7c55d7)    ![스크린샷 2025-02-04 175007](https://github.com/user-attachments/assets/ab791a15-a6a5-4cc1-a2dc-bad9ba833a52)


## PR 유형

- [ ] CSS 등 사용자 UI 디자인 변경

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).