### PR TITLE
[NPG-226] 어드민 페이지 월별 작성 게시글 카운트 조회 기능 추가

### DIFF
--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -13,7 +13,7 @@ export const getTotals = async () => {
 
 export const getMonthPostTotals = async () => {
   try {
-    const response = await axiosInstance.get('/api/dashboard/month/post');
+    const response = await axiosInstance.get('/api/dashboard/stats/post');
     return response.data;
   } catch (error) {
     throw new Error(

--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -10,3 +10,15 @@ export const getTotals = async () => {
     );
   }
 };
+
+
+export const getMonthPostTotals = async () => {
+  try {
+    const response = await axiosInstance.get('/api/dashboard/month/post');
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      `관리자 페이지를 불러오는 중 에러가 발생했습니다.: ${error.message}`,
+    );
+  }
+};

--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -11,7 +11,6 @@ export const getTotals = async () => {
   }
 };
 
-
 export const getMonthPostTotals = async () => {
   try {
     const response = await axiosInstance.get('/api/dashboard/month/post');

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -91,7 +91,6 @@ export default function Home() {
         const firstIndex = stats.findIndex(item => item.posts !== 0);
         
         let filteredStats = firstIndex !== -1 ? stats.slice(firstIndex) : [];
-        
 
         if (!filteredStats.some(item => item.name === currentMonth)) {
           filteredStats.push({ name: currentMonth, posts: monthData[currentMonth] || 0 });

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -1,9 +1,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line } from 'recharts';
 import { UserIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect } from 'react';
-import {
-  getTotals
-} from '../api/total';
+import { getTotals, getMonthPostTotals } from '../api/total';
 
 // 더미 데이터
 const userStats = [
@@ -13,15 +11,6 @@ const userStats = [
   { name: '4월', users: 800 },
   { name: '5월', users: 1000 },
   { name: '6월', users: 1200 },
-];
-
-const postStats = [
-  { name: '1월', posts: 200 },
-  { name: '2월', posts: 400 },
-  { name: '3월', posts: 300 },
-  { name: '4월', posts: 600 },
-  { name: '5월', posts: 800 },
-  { name: '6월', posts: 1000 },
 ];
 
 const dailyUserStats = [
@@ -79,19 +68,45 @@ const monthlyAverageLoginStats = [
 ];
 
 export default function Home() {
-const [totalData, setTotalData] = useState({});
+  const [totalData, setTotalData] = useState({});
+  const [postStats, setPostStats] = useState([]);
 
-    useEffect(() => {
-      const fetchData = async () => {
-        try {
-          const response = await getTotals();
-          setTotalData(response.data)
-        } catch (error) {
-          console.error('데이터 가져오기 에러: ', error);
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await getTotals();
+        setTotalData(response.data);
+      } catch (error) {
+        console.error('데이터 가져오기 에러: ', error);
+      }
+    };
+
+    const fetchMonthPostStats = async () => {
+      try {
+        const response = await getMonthPostTotals();
+        const monthData = response.data;
+        const stats = Object.entries(monthData).map(([month, count]) => ({ name: month, posts: count }));
+    
+        const currentMonth = `${("0" + (new Date().getMonth() + 1)).slice(-2)}월`;
+        const firstIndex = stats.findIndex(item => item.posts !== 0);
+        
+        let filteredStats = firstIndex !== -1 ? stats.slice(firstIndex) : [];
+        
+
+        if (!filteredStats.some(item => item.name === currentMonth)) {
+          filteredStats.push({ name: currentMonth, posts: monthData[currentMonth] || 0 });
         }
-      };
-      fetchData();
-    }, []);
+        
+        setPostStats(filteredStats);
+      } catch (error) {
+        console.error('월별 게시글 통계 가져오기 오류: ', error);
+      }
+    };
+
+    fetchData();
+    fetchMonthPostStats();
+  }, []);
+  
   return (
     <div className="p-6">
       {/* 통계 카드 */}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/community/repository/CommunityRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/community/repository/CommunityRepository.java
@@ -1,8 +1,10 @@
 package com.mars.admin.domain.community.repository;
 
 import com.mars.common.model.community.Community;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
-
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/community/repository/CommunityRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/community/repository/CommunityRepository.java
@@ -2,8 +2,16 @@ package com.mars.admin.domain.community.repository;
 
 import com.mars.common.model.community.Community;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
-    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    @Query("SELECT DATE_FORMAT(c.createdAt, '%Y-%m-01') as month, COUNT(c) as count " +
+        "FROM Community c " +
+        "WHERE c.createdAt BETWEEN :start AND :end " +
+        "GROUP BY DATE_FORMAT(c.createdAt, '%Y-%m-01') " +
+        "ORDER BY month DESC")
+    List<Object[]> getMonthPostCounts(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/community/repository/CommunityRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/community/repository/CommunityRepository.java
@@ -2,7 +2,6 @@ package com.mars.admin.domain.community.repository;
 
 import com.mars.common.model.community.Community;
 import java.time.LocalDateTime;
-import java.time.YearMonth;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -20,9 +20,8 @@ public class DashboardController {
         return ResponseDto.of(chartService.getTotals(), "");
     }
 
-
     @GetMapping("/stats/post")
-    public ResponseDto<Map<String, Long>> monthPostCountTotals(){
+    public ResponseDto<Map<String, Long>> monthPostCountTotals() {
         return ResponseDto.of(chartService.getPostMonthCountTotals());
     }
- }
+}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -19,4 +19,10 @@ public class DashboardController {
     public ResponseDto<Map<String, Long>> dashboard() {
         return ResponseDto.of(chartService.getTotals(), "");
     }
-}
+
+
+    @GetMapping("/month/post")
+    public ResponseDto<Map<String, Long>> monthPostCountTotals(){
+        return ResponseDto.of(chartService.getPostMonthCountTotals());
+    }
+ }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -21,7 +21,7 @@ public class DashboardController {
     }
 
 
-    @GetMapping("/month/post")
+    @GetMapping("/stats/post")
     public ResponseDto<Map<String, Long>> monthPostCountTotals(){
         return ResponseDto.of(chartService.getPostMonthCountTotals());
     }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -2,6 +2,10 @@ package com.mars.admin.domain.dashboard.service;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
 import com.mars.admin.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +23,27 @@ public class ChartService {
             "userCount", userRepository.count(),
             "communityCount", communityRepository.count()
         );
+    }
+
+    public Map<String, Long> getPostMonthCountTotals(){
+        YearMonth now = YearMonth.now();
+
+        Map<String, Long> monthlyPostCounts = new LinkedHashMap<>();
+
+        for (int i = 11; i >= 0; i--) {
+            YearMonth yearMonth = now.minusMonths(i);
+            String monthKey = yearMonth.format(DateTimeFormatter.ofPattern("MM")) + "월";
+            long postCount = getMonthPostCount(yearMonth);
+            monthlyPostCounts.put(monthKey, postCount);
+        }
+
+        return monthlyPostCounts;
+    }
+
+    private long getMonthPostCount(YearMonth yearMonth){
+        LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime end = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+        return communityRepository.countByCreatedAtBetween(start, end);
     }
 
     private long getUserTotalCount(){

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -1,6 +1,5 @@
 package com.mars.admin.domain.dashboard.service;
 
-import static com.mars.common.enums.user.UserStatus.ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
@@ -31,15 +30,15 @@ class ChartServiceTest extends IntegrationTestSupport {
     private ChartService chartService;
     @Autowired
     private UserService userService;
-    
-    private User createUser(){
+
+    private User createUser() {
         return User.builder()
             .email("test@example.com")
             .build();
     }
 
     private Community createCommunity(User user) {
-        return Community.of(user, "제목", "내용", "",true);
+        return Community.of(user, "제목", "내용", "", true);
     }
 
     @DisplayName("이번 달 게시글 총합 수를 조회할 수 있다.")
@@ -51,7 +50,7 @@ class ChartServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         List<Community> posts = new ArrayList<>();
-        for(int i=0; i <5; i++){
+        for (int i = 0; i < 5; i++) {
             posts.add(createCommunity(user));
         }
         communityRepository.saveAll(posts);

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -1,0 +1,69 @@
+package com.mars.admin.domain.dashboard.service;
+
+import static com.mars.common.enums.user.UserStatus.ACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mars.admin.domain.community.repository.CommunityRepository;
+import com.mars.admin.domain.user.repository.UserRepository;
+import com.mars.admin.domain.user.service.UserService;
+import com.mars.admin.support.IntegrationTestSupport;
+import com.mars.common.model.community.Community;
+import com.mars.common.model.user.User;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class ChartServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CommunityRepository communityRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChartService chartService;
+    @Autowired
+    private UserService userService;
+    
+    private User createUser(){
+        return User.builder()
+            .email("test@example.com")
+            .build();
+    }
+
+    private Community createCommunity(User user) {
+        return Community.of(user, "제목", "내용", "",true);
+    }
+
+    @DisplayName("이번 달 게시글 총합 수를 조회할 수 있다.")
+    @Test
+    void getPostMonthCountTotals() {
+        // given
+        User user = createUser();
+
+        userRepository.save(user);
+
+        List<Community> posts = new ArrayList<>();
+        for(int i=0; i <5; i++){
+            posts.add(createCommunity(user));
+        }
+        communityRepository.saveAll(posts);
+
+        String currentMonthKey = YearMonth.now().format(DateTimeFormatter.ofPattern("MM")) + "월";
+
+        // when
+        Map<String, Long> totals = chartService.getPostMonthCountTotals();
+
+        // then
+        assertThat(totals.size()).isEqualTo(12);
+        assertThat(totals).containsKey(currentMonthKey);
+        assertThat(totals.get(currentMonthKey)).isEqualTo(5L);
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 어드민 페이지 대시보드 조회 시 월별 작성 게시글 통계를 추가했습니다.
    - 조회한 날짜 기준으로 1년 이내의 데이터를 조회하여 가져옵니다.
    - 조회한 데이터가 연속으로 0일 경우 안 보이도록 하였습니다. 
    ex)  1월부터~7월은 데이터가 0이고, 이후 날짜부터 데이터가 있을 경우 8월부터 데이터를 보여주게 됩니다.

- 테스트 코드는 작성일자를 건드려야 하지만,
 테스트를 위해 프로덕션 코드를 수정하는 것이 바람직하지않다고 생각해서 우선은 추가하지 않고,
  직접 게시글을 작성해서 조회가 되는지 여부와 DB에서 날짜를 바꿔 조회되는지 확인했습니다.
     
> 
![image](https://github.com/user-attachments/assets/3637619e-8228-4fc6-a9ad-4acbefd3c7f4)



## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).