### PR TITLE
[NPG-224] Admin - 월별 회원가입 카운트 조회 기능 추가 및 통계 관련 API 통합

### DIFF
--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -1,6 +1,6 @@
 import axiosInstance from './axiosInstance';
 
-export const getDashboardData = async (months = 12) => {
+export const getDashboardData = async (months) => {
   try {
     const response = await axiosInstance.get(`/api/dashboard?months=${months}`);
     return response.data;

--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -1,12 +1,12 @@
 import axiosInstance from './axiosInstance';
 
-export const getTotals = async () => {
+export const getDashboardData = async (months = 12) => {
   try {
-    const response = await axiosInstance.get('/api/dashboard');
+    const response = await axiosInstance.get(`/api/dashboard?months=${months}`);
     return response.data;
   } catch (error) {
     throw new Error(
-      `관리자 페이지를 불러오는 중 에러가 발생했습니다.: ${error.message}`,
+      `대시보드 데이터를 불러오는 중 에러가 발생했습니다: ${error.message}`
     );
   }
 };
@@ -17,7 +17,7 @@ export const getMonthPostTotals = async () => {
     return response.data;
   } catch (error) {
     throw new Error(
-      `관리자 페이지를 불러오는 중 에러가 발생했습니다.: ${error.message}`,
+      `월별 게시물 통계를 불러오는 중 에러가 발생했습니다: ${error.message}`
     );
   }
 };

--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -10,14 +10,3 @@ export const getDashboardData = async (months = 12) => {
     );
   }
 };
-
-export const getMonthPostTotals = async () => {
-  try {
-    const response = await axiosInstance.get('/api/dashboard/stats/post');
-    return response.data;
-  } catch (error) {
-    throw new Error(
-      `월별 게시물 통계를 불러오는 중 에러가 발생했습니다: ${error.message}`
-    );
-  }
-};

--- a/NangPaGo-admin/src/api/total.js
+++ b/NangPaGo-admin/src/api/total.js
@@ -1,8 +1,8 @@
 import axiosInstance from './axiosInstance';
 
-export const getDashboardData = async (months) => {
+export const getDashboardData = async () => {
   try {
-    const response = await axiosInstance.get(`/api/dashboard?months=${months}`);
+    const response = await axiosInstance.get(`/api/dashboard`);
     return response.data;
   } catch (error) {
     throw new Error(

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -60,11 +60,12 @@ const monthlyAverageLoginStats = [
 
 export default function Home() {
   const [dashboardData, setDashboardData] = useState({});
+  const [months, setMonths] = useState(11);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await getDashboardData();
+      const response = await getDashboardData(months);
         setDashboardData(response.data);
       } catch (error) {
         console.error('대시보드 데이터 가져오기 에러: ', error);
@@ -130,7 +131,7 @@ export default function Home() {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 게시글 통계</h3>
-            <BarChart width={500} height={300} data={dashboardData.communityCountData}>
+            <BarChart width={500} height={300} data={dashboardData.monthPostCountData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -1,7 +1,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line } from 'recharts';
 import { UserIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect } from 'react';
-import { getDashboardData, getMonthPostTotals } from '../api/total';
+import { getDashboardData } from '../api/total';
 
 // 더미 데이터
 const dailyUserStats = [
@@ -60,7 +60,6 @@ const monthlyAverageLoginStats = [
 
 export default function Home() {
   const [dashboardData, setDashboardData] = useState({});
-  const [postStats, setPostStats] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -72,21 +71,7 @@ export default function Home() {
       }
     };
 
-    const fetchMonthPostStats = async () => {
-      try {
-        const response = await getMonthPostTotals();
-        const stats = response.data.map(item => ({
-          month: `${item.month}`,
-          count: item.count
-        }));
-        setPostStats(stats);
-      } catch (error) {
-        console.error('월별 게시글 통계 가져오기 오류: ', error);
-      }
-    };
-
     fetchData();
-    fetchMonthPostStats();
   }, []);
 
   return (
@@ -145,7 +130,7 @@ export default function Home() {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 게시글 통계</h3>
-            <BarChart width={500} height={300} data={postStats}>
+            <BarChart width={500} height={300} data={dashboardData.communityCountData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -75,19 +75,11 @@ export default function Home() {
     const fetchMonthPostStats = async () => {
       try {
         const response = await getMonthPostTotals();
-        const monthData = response.data;
-        const stats = Object.entries(monthData).map(([month, count]) => ({ name: month, posts: count }));
-
-        const currentMonth = `${("0" + (new Date().getMonth() + 1)).slice(-2)}월`;
-        const firstIndex = stats.findIndex(item => item.posts !== 0);
-
-        let filteredStats = firstIndex !== -1 ? stats.slice(firstIndex) : [];
-
-        if (!filteredStats.some(item => item.name === currentMonth)) {
-          filteredStats.push({ name: currentMonth, posts: monthData[currentMonth] || 0 });
-        }
-
-        setPostStats(filteredStats);
+        const stats = response.data.map(item => ({
+          month: `${item.month}`,
+          count: item.count
+        }));
+        setPostStats(stats);
       } catch (error) {
         console.error('월별 게시글 통계 가져오기 오류: ', error);
       }
@@ -155,11 +147,11 @@ export default function Home() {
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 게시글 통계</h3>
             <BarChart width={500} height={300} data={postStats}>
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
+              <XAxis dataKey="month" />
               <YAxis />
               <Tooltip />
               <Legend />
-              <Bar dataKey="posts" fill="#82ca9d" />
+              <Bar dataKey="count" fill="#82ca9d" />
             </BarChart>
           </div>
         </div>

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -1,18 +1,9 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line } from 'recharts';
 import { UserIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect } from 'react';
-import { getTotals, getMonthPostTotals } from '../api/total';
+import { getDashboardData, getMonthPostTotals } from '../api/total';
 
 // 더미 데이터
-const userStats = [
-  { name: '1월', users: 400 },
-  { name: '2월', users: 300 },
-  { name: '3월', users: 600 },
-  { name: '4월', users: 800 },
-  { name: '5월', users: 1000 },
-  { name: '6월', users: 1200 },
-];
-
 const dailyUserStats = [
   { name: '6/7', users: 0 },
   { name: '6/8', users: 445 },
@@ -68,16 +59,16 @@ const monthlyAverageLoginStats = [
 ];
 
 export default function Home() {
-  const [totalData, setTotalData] = useState({});
+  const [dashboardData, setDashboardData] = useState({});
   const [postStats, setPostStats] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await getTotals();
-        setTotalData(response.data);
+        const response = await getDashboardData();
+        setDashboardData(response.data);
       } catch (error) {
-        console.error('데이터 가져오기 에러: ', error);
+        console.error('대시보드 데이터 가져오기 에러: ', error);
       }
     };
 
@@ -86,16 +77,16 @@ export default function Home() {
         const response = await getMonthPostTotals();
         const monthData = response.data;
         const stats = Object.entries(monthData).map(([month, count]) => ({ name: month, posts: count }));
-    
+
         const currentMonth = `${("0" + (new Date().getMonth() + 1)).slice(-2)}월`;
         const firstIndex = stats.findIndex(item => item.posts !== 0);
-        
+
         let filteredStats = firstIndex !== -1 ? stats.slice(firstIndex) : [];
 
         if (!filteredStats.some(item => item.name === currentMonth)) {
           filteredStats.push({ name: currentMonth, posts: monthData[currentMonth] || 0 });
         }
-        
+
         setPostStats(filteredStats);
       } catch (error) {
         console.error('월별 게시글 통계 가져오기 오류: ', error);
@@ -105,7 +96,7 @@ export default function Home() {
     fetchData();
     fetchMonthPostStats();
   }, []);
-  
+
   return (
     <div className="p-6">
       {/* 통계 카드 */}
@@ -119,7 +110,7 @@ export default function Home() {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">총 사용자</dt>
-                  <dd className="text-3xl font-semibold text-gray-900">{totalData.userCount || 0}</dd>
+                  <dd className="text-3xl font-semibold text-gray-900">{dashboardData.totals?.userCount || 0}</dd>
                 </dl>
               </div>
             </div>
@@ -135,7 +126,7 @@ export default function Home() {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">총 게시글</dt>
-                  <dd className="text-3xl font-semibold text-gray-900">{totalData.communityCount || 0}</dd>
+                  <dd className="text-3xl font-semibold text-gray-900">{dashboardData.totals?.communityCount || 0}</dd>
                 </dl>
               </div>
             </div>
@@ -147,15 +138,15 @@ export default function Home() {
       <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2">
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
-            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 사용자 통계</h3>
-            <LineChart width={500} height={300} data={userStats}>
+            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 회원가입 통계</h3>
+            <BarChart width={500} height={300} data={dashboardData.monthlyData}>
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
+              <XAxis dataKey="month" />
               <YAxis />
               <Tooltip />
               <Legend />
-              <Line type="monotone" dataKey="users" stroke="#8884d8" />
-            </LineChart>
+              <Bar dataKey="userCount" name="사용자 수" fill="#82ca9d" />
+            </BarChart>
           </div>
         </div>
 
@@ -215,4 +206,4 @@ export default function Home() {
       </div>
     </div>
   )
-} 
+}

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line, ComposedChart, } from 'recharts';
 import { UserIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect } from 'react';
 import { getDashboardData } from '../api/total';
@@ -87,8 +87,12 @@ export default function Home() {
               </div>
               <div className="ml-5 w-0 flex-1">
                 <dl>
-                  <dt className="text-sm font-medium text-gray-500 truncate">총 사용자</dt>
-                  <dd className="text-3xl font-semibold text-gray-900">{dashboardData.totals?.userCount || 0}</dd>
+                  <dt className="text-sm font-medium text-gray-500 truncate">
+                    총 사용자
+                  </dt>
+                  <dd className="text-3xl font-semibold text-gray-900">
+                    {dashboardData.totals?.userCount || 0}
+                  </dd>
                 </dl>
               </div>
             </div>
@@ -103,8 +107,12 @@ export default function Home() {
               </div>
               <div className="ml-5 w-0 flex-1">
                 <dl>
-                  <dt className="text-sm font-medium text-gray-500 truncate">총 게시글</dt>
-                  <dd className="text-3xl font-semibold text-gray-900">{dashboardData.totals?.communityCount || 0}</dd>
+                  <dt className="text-sm font-medium text-gray-500 truncate">
+                    총 게시글
+                  </dt>
+                  <dd className="text-3xl font-semibold text-gray-900">
+                    {dashboardData.totals?.communityCount || 0}
+                  </dd>
                 </dl>
               </div>
             </div>
@@ -116,22 +124,23 @@ export default function Home() {
       <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2">
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
-            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 회원가입 통계</h3>
-            <BarChart width={500} height={300} data={dashboardData.monthlyRegisterData}>
+            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 회원가입통계</h3>
+            <ComposedChart width={600} height={300} data={dashboardData.monthlyRegisterData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
               <Tooltip />
               <Legend />
-              <Bar dataKey="userCount" name="사용자 수" fill="#82ca9d" />
-            </BarChart>
+              <Bar dataKey="userCount" name="사용자 수" fill="#87CEEB" />
+              <Line type="monotone" dataKey="userCount" stroke="#8884d8" />
+            </ComposedChart>
           </div>
         </div>
 
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 게시글 통계</h3>
-            <BarChart width={500} height={300} data={dashboardData.monthPostCountData}>
+            <BarChart width={600} height={300} data={dashboardData.monthPostCountData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
@@ -145,7 +154,7 @@ export default function Home() {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">일일 접속자 통계</h3>
-            <LineChart width={500} height={300} data={dailyUserStats}>
+            <LineChart width={600} height={300} data={dailyUserStats}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />
               <YAxis />
@@ -155,10 +164,11 @@ export default function Home() {
             </LineChart>
           </div>
         </div>
+
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월 평균 시간대별 사용자 활동 현황</h3>
-            <LineChart width={500} height={300} data={monthlyAverageLoginStats}>
+            <LineChart width={600} height={300} data={monthlyAverageLoginStats}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis
                 dataKey="time"
@@ -183,5 +193,5 @@ export default function Home() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/NangPaGo-admin/src/pages/Home.jsx
+++ b/NangPaGo-admin/src/pages/Home.jsx
@@ -117,7 +117,7 @@ export default function Home() {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 회원가입 통계</h3>
-            <BarChart width={500} height={300} data={dashboardData.monthlyData}>
+            <BarChart width={500} height={300} data={dashboardData.monthlyRegisterData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
@@ -137,7 +137,7 @@ export default function Home() {
               <YAxis />
               <Tooltip />
               <Legend />
-              <Bar dataKey="count" fill="#82ca9d" />
+              <Bar dataKey="count" name="게시글 수" fill="#82ca9d" />
             </BarChart>
           </div>
         </div>

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -2,6 +2,7 @@ package com.mars.admin.domain.dashboard.controller;
 
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto.DashboardData;
+import com.mars.admin.domain.dashboard.dto.MonthCommunityCountDto;
 import com.mars.admin.domain.dashboard.service.ChartService;
 import com.mars.common.dto.ResponseDto;
 import java.util.List;
@@ -29,7 +30,7 @@ public class DashboardController {
     }
 
     @GetMapping("/stats/post")
-    public ResponseDto<Map<String, Long>> monthPostCountTotals() {
+    public ResponseDto<List<MonthCommunityCountDto>> monthPostCountTotals() {
         return ResponseDto.of(chartService.getPostMonthCountTotals());
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -21,10 +21,10 @@ public class DashboardController {
     private final ChartService chartService;
 
     @GetMapping
-    public ResponseDto<DashboardResponseDto> getDashboardData(int months) {
+    public ResponseDto<DashboardResponseDto> getDashboardData() {
         Map<String, Long> totals = chartService.getTotals();
-        List<MonthRegisterCountDto> monthlyRegisterData = chartService.getMonthlyRegisterCounts(months);
-        List<MonthPostCountDto> monthPostCountData = chartService.getPostMonthCountTotals(months);
+        List<MonthRegisterCountDto> monthlyRegisterData = chartService.getMonthlyRegisterCounts();
+        List<MonthPostCountDto> monthPostCountData = chartService.getPostMonthCountTotals();
         DashboardResponseDto dashboardResponseDto = DashboardResponseDto.of(totals, monthlyRegisterData,
             monthPostCountData);
         return ResponseDto.of(dashboardResponseDto);

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -1,8 +1,8 @@
 package com.mars.admin.domain.dashboard.controller;
 
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
-import com.mars.admin.domain.dashboard.dto.DashboardResponseDto.DashboardData;
 import com.mars.admin.domain.dashboard.dto.MonthPostCountDto;
+import com.mars.admin.domain.dashboard.dto.MonthRegisterCountDto;
 import com.mars.admin.domain.dashboard.service.ChartService;
 import com.mars.common.dto.ResponseDto;
 import java.util.List;
@@ -21,12 +21,12 @@ public class DashboardController {
     private final ChartService chartService;
 
     @GetMapping
-    public ResponseDto<DashboardData> getDashboardData(@RequestParam(defaultValue = "11") int months) {
+    public ResponseDto<DashboardResponseDto> getDashboardData(int months) {
         Map<String, Long> totals = chartService.getTotals();
-        List<DashboardResponseDto> monthlyData = chartService.getMonthlyRegisterCounts(months);
-        List<MonthPostCountDto> monthPostCountData = chartService.getMonthPostCountTotals();
+        List<MonthRegisterCountDto> monthlyRegisterData = chartService.getMonthlyRegisterCounts(months);
+        List<MonthPostCountDto> monthPostCountData = chartService.getPostMonthCountTotals();
 
-        DashboardData dashboardData = new DashboardData(totals, monthlyData, monthPostCountData);
-        return ResponseDto.of(dashboardData, "");
+        DashboardResponseDto dashboardResponseDto = DashboardResponseDto.of(totals, monthlyRegisterData, monthPostCountData);
+        return ResponseDto.of(dashboardResponseDto);
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -2,7 +2,7 @@ package com.mars.admin.domain.dashboard.controller;
 
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto.DashboardData;
-import com.mars.admin.domain.dashboard.dto.MonthCommunityCountDto;
+import com.mars.admin.domain.dashboard.dto.MonthPostCountDto;
 import com.mars.admin.domain.dashboard.service.ChartService;
 import com.mars.common.dto.ResponseDto;
 import java.util.List;
@@ -21,12 +21,12 @@ public class DashboardController {
     private final ChartService chartService;
 
     @GetMapping
-    public ResponseDto<DashboardData> getDashboardData(@RequestParam(defaultValue = "12") int months) {
+    public ResponseDto<DashboardData> getDashboardData(@RequestParam(defaultValue = "11") int months) {
         Map<String, Long> totals = chartService.getTotals();
         List<DashboardResponseDto> monthlyData = chartService.getMonthlyRegisterCounts(months);
-        List<MonthCommunityCountDto> monthCommunityCountData = chartService.getPostMonthCountTotals();
+        List<MonthPostCountDto> monthPostCountData = chartService.getMonthPostCountTotals();
 
-        DashboardData dashboardData = new DashboardData(totals, monthlyData, monthCommunityCountData);
-        return ResponseDto.of(dashboardData, "Dashboard data retrieved successfully");
+        DashboardData dashboardData = new DashboardData(totals, monthlyData, monthPostCountData);
+        return ResponseDto.of(dashboardData, "");
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -24,9 +24,9 @@ public class DashboardController {
     public ResponseDto<DashboardResponseDto> getDashboardData(int months) {
         Map<String, Long> totals = chartService.getTotals();
         List<MonthRegisterCountDto> monthlyRegisterData = chartService.getMonthlyRegisterCounts(months);
-        List<MonthPostCountDto> monthPostCountData = chartService.getPostMonthCountTotals();
-
-        DashboardResponseDto dashboardResponseDto = DashboardResponseDto.of(totals, monthlyRegisterData, monthPostCountData);
+        List<MonthPostCountDto> monthPostCountData = chartService.getPostMonthCountTotals(months);
+        DashboardResponseDto dashboardResponseDto = DashboardResponseDto.of(totals, monthlyRegisterData,
+            monthPostCountData);
         return ResponseDto.of(dashboardResponseDto);
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -24,13 +24,9 @@ public class DashboardController {
     public ResponseDto<DashboardData> getDashboardData(@RequestParam(defaultValue = "12") int months) {
         Map<String, Long> totals = chartService.getTotals();
         List<DashboardResponseDto> monthlyData = chartService.getMonthlyRegisterCounts(months);
+        List<MonthCommunityCountDto> monthCommunityCountData = chartService.getPostMonthCountTotals();
 
-        DashboardData dashboardData = new DashboardData(totals, monthlyData);
+        DashboardData dashboardData = new DashboardData(totals, monthlyData, monthCommunityCountData);
         return ResponseDto.of(dashboardData, "Dashboard data retrieved successfully");
-    }
-
-    @GetMapping("/stats/post")
-    public ResponseDto<List<MonthCommunityCountDto>> monthPostCountTotals() {
-        return ResponseDto.of(chartService.getPostMonthCountTotals());
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -1,11 +1,15 @@
 package com.mars.admin.domain.dashboard.controller;
 
+import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
+import com.mars.admin.domain.dashboard.dto.DashboardResponseDto.DashboardData;
 import com.mars.admin.domain.dashboard.service.ChartService;
 import com.mars.common.dto.ResponseDto;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -16,8 +20,12 @@ public class DashboardController {
     private final ChartService chartService;
 
     @GetMapping
-    public ResponseDto<Map<String, Long>> dashboard() {
-        return ResponseDto.of(chartService.getTotals(), "");
+    public ResponseDto<DashboardData> getDashboardData(@RequestParam(defaultValue = "12") int months) {
+        Map<String, Long> totals = chartService.getTotals();
+        List<DashboardResponseDto> monthlyData = chartService.getMonthlyRegisterCounts(months);
+
+        DashboardData dashboardData = new DashboardData(totals, monthlyData);
+        return ResponseDto.of(dashboardData, "Dashboard data retrieved successfully");
     }
 
     @GetMapping("/stats/post")

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
@@ -3,23 +3,22 @@ package com.mars.admin.domain.dashboard.dto;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
-import lombok.Getter;
 
 @Builder
-public record DashboardResponseDto(Integer year, Integer month, Long userCount) {
-
-    @Getter
-    @Builder
-    public static class DashboardData {
-        private Map<String, Long> totals;
-        private List<DashboardResponseDto> monthlyData;
-        private List<MonthPostCountDto> monthPostCountData;
-
-        public DashboardData(Map<String, Long> totals, List<DashboardResponseDto> monthlyData,
-            List<MonthPostCountDto> monthPostCountData) {
-            this.totals = totals;
-            this.monthlyData = monthlyData;
-            this.monthPostCountData = monthPostCountData;
-        }
+public record DashboardResponseDto(
+    Map<String, Long> totals,
+    List<MonthRegisterCountDto> monthlyRegisterData,
+    List<MonthPostCountDto> monthPostCountData
+) {
+    public static DashboardResponseDto of(
+        Map<String, Long> totals,
+        List<MonthRegisterCountDto> monthlyRegisterData,
+        List<MonthPostCountDto> monthPostCountData
+    ) {
+        return DashboardResponseDto.builder()
+            .totals(totals)
+            .monthlyRegisterData(monthlyRegisterData)
+            .monthPostCountData(monthPostCountData)
+            .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
@@ -13,11 +13,13 @@ public record DashboardResponseDto(Integer year, Integer month, Long userCount) 
     public static class DashboardData {
         private Map<String, Long> totals;
         private List<DashboardResponseDto> monthlyData;
+        private List<MonthCommunityCountDto> communityCountData;
 
-        public DashboardData(Map<String, Long> totals, List<DashboardResponseDto> monthlyData) {
+        public DashboardData(Map<String, Long> totals, List<DashboardResponseDto> monthlyData,
+            List<MonthCommunityCountDto> communityCountData) {
             this.totals = totals;
             this.monthlyData = monthlyData;
+            this.communityCountData = communityCountData;
         }
-
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
@@ -1,0 +1,23 @@
+package com.mars.admin.domain.dashboard.dto;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public record DashboardResponseDto(Integer year, Integer month, Long userCount) {
+
+    @Getter
+    @Builder
+    public static class DashboardData {
+        private Map<String, Long> totals;
+        private List<DashboardResponseDto> monthlyData;
+
+        public DashboardData(Map<String, Long> totals, List<DashboardResponseDto> monthlyData) {
+            this.totals = totals;
+            this.monthlyData = monthlyData;
+        }
+
+    }
+}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
@@ -13,13 +13,13 @@ public record DashboardResponseDto(Integer year, Integer month, Long userCount) 
     public static class DashboardData {
         private Map<String, Long> totals;
         private List<DashboardResponseDto> monthlyData;
-        private List<MonthCommunityCountDto> communityCountData;
+        private List<MonthPostCountDto> monthPostCountData;
 
         public DashboardData(Map<String, Long> totals, List<DashboardResponseDto> monthlyData,
-            List<MonthCommunityCountDto> communityCountData) {
+            List<MonthPostCountDto> monthPostCountData) {
             this.totals = totals;
             this.monthlyData = monthlyData;
-            this.communityCountData = communityCountData;
+            this.monthPostCountData = monthPostCountData;
         }
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/MonthCommunityCountDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/MonthCommunityCountDto.java
@@ -1,0 +1,19 @@
+package com.mars.admin.domain.dashboard.dto;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+
+@Builder
+public record MonthCommunityCountDto(
+    String month,
+    long count
+) {
+
+    public static MonthCommunityCountDto of(YearMonth yearMonth, long count) {
+        return MonthCommunityCountDto.builder()
+            .month(yearMonth.format(DateTimeFormatter.ofPattern("MM")) + "월")
+            .count(count)
+            .build();
+    }
+}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/MonthPostCountDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/MonthPostCountDto.java
@@ -5,13 +5,13 @@ import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 
 @Builder
-public record MonthCommunityCountDto(
+public record MonthPostCountDto(
     String month,
     long count
 ) {
 
-    public static MonthCommunityCountDto of(YearMonth yearMonth, long count) {
-        return MonthCommunityCountDto.builder()
+    public static MonthPostCountDto of(YearMonth yearMonth, long count) {
+        return MonthPostCountDto.builder()
             .month(yearMonth.format(DateTimeFormatter.ofPattern("MM")) + "월")
             .count(count)
             .build();

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/MonthRegisterCountDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/MonthRegisterCountDto.java
@@ -1,0 +1,20 @@
+package com.mars.admin.domain.dashboard.dto;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+
+@Builder
+public record MonthRegisterCountDto(
+    String year,
+    String month,
+    long userCount
+) {
+    public static MonthRegisterCountDto of(YearMonth yearMonth, long userCount) {
+        return MonthRegisterCountDto.builder()
+            .year(yearMonth.format(DateTimeFormatter.ofPattern("yyyy")) + "년")
+            .month(yearMonth.format(DateTimeFormatter.ofPattern("MM")) + "월")
+            .userCount(userCount)
+            .build();
+    }
+}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -5,7 +5,6 @@ import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
 import com.mars.admin.domain.dashboard.dto.MonthCommunityCountDto;
 import com.mars.admin.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -1,8 +1,10 @@
 package com.mars.admin.domain.dashboard.service;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
+import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
 import com.mars.admin.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
@@ -25,6 +27,25 @@ public class ChartService {
             "userCount", userRepository.count(),
             "communityCount", communityRepository.count()
         );
+    }
+
+    public List<DashboardResponseDto> getMonthlyRegisterCounts(int months) {
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusMonths(months);
+
+        List<Object[]> monthlyRegisterCounts = userRepository.getMonthRegisterCount(startDate, endDate);
+        List<DashboardResponseDto> userCountDto = new ArrayList<>();
+
+        for (Object[] row : monthlyRegisterCounts) {
+            int year = ((Number) row[0]).intValue();
+            int month = ((Number) row[1]).intValue();
+            long userCount = ((Number) row[2]).longValue();
+            System.out.println(year + "-" + month + "-" + userCount);
+            userCountDto.add(new DashboardResponseDto(year, month, userCount));
+        }
+
+        System.out.println(userCountDto);
+        return userCountDto;
     }
 
     public Map<String, Long> getPostMonthCountTotals() {

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -2,7 +2,7 @@ package com.mars.admin.domain.dashboard.service;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
-import com.mars.admin.domain.dashboard.dto.MonthCommunityCountDto;
+import com.mars.admin.domain.dashboard.dto.MonthPostCountDto;
 import com.mars.admin.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -40,15 +40,14 @@ public class ChartService {
             int year = ((Number) row[0]).intValue();
             int month = ((Number) row[1]).intValue();
             long userCount = ((Number) row[2]).longValue();
-            System.out.println(year + "-" + month + "-" + userCount);
+
             userCountDto.add(new DashboardResponseDto(year, month, userCount));
         }
 
-        System.out.println(userCountDto);
         return userCountDto;
     }
 
-    public List<MonthCommunityCountDto> getPostMonthCountTotals() {
+    public List<MonthPostCountDto> getMonthPostCountTotals() {
         List<YearMonth> months = resetMonths();
         Map<YearMonth, Long> postCounts = getMonthPostCounts().stream()
             .collect(Collectors.toMap(
@@ -56,7 +55,7 @@ public class ChartService {
                 result -> (Long) result[1]
             ));
 
-        List<MonthCommunityCountDto> result = new ArrayList<>();
+        List<MonthPostCountDto> result = new ArrayList<>();
 
         boolean foundPosts = false;
         for (YearMonth month : months) {
@@ -65,7 +64,7 @@ public class ChartService {
                 foundPosts = true;
             }
             if (foundPosts) {
-                result.add(MonthCommunityCountDto.of(month, count));
+                result.add(MonthPostCountDto.of(month, count));
             }
         }
 
@@ -89,13 +88,5 @@ public class ChartService {
         LocalDateTime end = now.atEndOfMonth().atTime(23, 59, 59);
 
         return communityRepository.getMonthPostCounts(start, end);
-    }
-
-    private long getUserTotalCount() {
-        return userRepository.count();
-    }
-
-    private long getCommunityTotalCount() {
-        return communityRepository.count();
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ChartService {
 
+    private static int MONTHS = 12;
     private final UserRepository userRepository;
     private final CommunityRepository communityRepository;
 
@@ -29,9 +30,9 @@ public class ChartService {
         );
     }
 
-    public List<MonthRegisterCountDto> getMonthlyRegisterCounts(int months) {
+    public List<MonthRegisterCountDto> getMonthlyRegisterCounts() {
         YearMonth now = YearMonth.now();
-        Map<YearMonth, Long> map = monthRegisterToMap(months);
+        Map<YearMonth, Long> map = monthRegisterToMap();
         List<MonthRegisterCountDto> monthPostCountDtos = new ArrayList<>();
 
         YearMonth startDate = map.keySet().stream().findFirst().orElse(null);
@@ -47,9 +48,9 @@ public class ChartService {
         return monthPostCountDtos;
     }
 
-    public List<MonthPostCountDto> getPostMonthCountTotals(int months) {
+    public List<MonthPostCountDto> getPostMonthCountTotals() {
         YearMonth now = YearMonth.now();
-        Map<YearMonth, Long> map = monthPostCountToMap(months);
+        Map<YearMonth, Long> map = monthPostCountToMap();
         List<MonthPostCountDto> monthPostCountDtos = new ArrayList<>();
 
         YearMonth startDate = map.keySet().stream().findFirst().orElse(null);
@@ -65,17 +66,17 @@ public class ChartService {
         return monthPostCountDtos;
     }
 
-    private Map<YearMonth, Long> monthPostCountToMap(int months) {
-        return getMonthPostCounts(months).stream()
+    private Map<YearMonth, Long> monthPostCountToMap() {
+        return getMonthPostCounts().stream()
             .collect(Collectors.toMap(
                 result -> YearMonth.parse(((String) result[0]).substring(0, 7)),
                 result -> (Long) result[1]
             ));
     }
 
-    private List<Object[]> getMonthPostCounts(int months) {
+    private List<Object[]> getMonthPostCounts() {
         YearMonth now = YearMonth.now();
-        YearMonth startMonth = now.minusMonths(months);
+        YearMonth startMonth = now.minusMonths(MONTHS - 1);
 
         LocalDateTime start = startMonth.atDay(1).atStartOfDay();
         LocalDateTime end = now.atEndOfMonth().atTime(23, 59, 59);
@@ -83,17 +84,17 @@ public class ChartService {
         return communityRepository.getMonthPostCounts(start, end);
     }
 
-    private Map<YearMonth, Long> monthRegisterToMap(int months) {
-        return getMonthRegisterCounts(months).stream()
+    private Map<YearMonth, Long> monthRegisterToMap() {
+        return getMonthRegisterCounts().stream()
             .collect(Collectors.toMap(
                 result -> YearMonth.of(((Number) result[0]).intValue(), ((Number) result[1]).intValue()),
                 result -> ((Number) result[2]).longValue()
             ));
     }
 
-    private List<Object[]> getMonthRegisterCounts(int months) {
+    private List<Object[]> getMonthRegisterCounts() {
         YearMonth now = YearMonth.now();
-        YearMonth startMonth = now.minusMonths(months);
+        YearMonth startMonth = now.minusMonths(MONTHS - 1);
 
         LocalDateTime start = startMonth.atDay(1).atStartOfDay();
         LocalDateTime end = now.atEndOfMonth().atTime(23, 59, 59);

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -31,7 +31,7 @@ public class ChartService {
 
     public List<MonthRegisterCountDto> getMonthlyRegisterCounts(int months) {
         YearMonth now = YearMonth.now();
-        Map<YearMonth, Long> map = MonthRegisterToMap(months);
+        Map<YearMonth, Long> map = monthRegisterToMap(months);
         List<MonthRegisterCountDto> monthPostCountDtos = new ArrayList<>();
 
         YearMonth startDate = map.keySet().stream().findFirst().orElse(null);
@@ -49,7 +49,7 @@ public class ChartService {
 
     public List<MonthPostCountDto> getPostMonthCountTotals(int months) {
         YearMonth now = YearMonth.now();
-        Map<YearMonth, Long> map = MonthPostCountToMap(months);
+        Map<YearMonth, Long> map = monthPostCountToMap(months);
         List<MonthPostCountDto> monthPostCountDtos = new ArrayList<>();
 
         YearMonth startDate = map.keySet().stream().findFirst().orElse(null);
@@ -65,7 +65,7 @@ public class ChartService {
         return monthPostCountDtos;
     }
 
-    private Map<YearMonth, Long> MonthPostCountToMap(int months) {
+    private Map<YearMonth, Long> monthPostCountToMap(int months) {
         return getMonthPostCounts(months).stream()
             .collect(Collectors.toMap(
                 result -> YearMonth.parse(((String) result[0]).substring(0, 7)),
@@ -83,7 +83,7 @@ public class ChartService {
         return communityRepository.getMonthPostCounts(start, end);
     }
 
-    private Map<YearMonth, Long> MonthRegisterToMap(int months) {
+    private Map<YearMonth, Long> monthRegisterToMap(int months) {
         return getMonthRegisterCounts(months).stream()
             .collect(Collectors.toMap(
                 result -> YearMonth.of(((Number) result[0]).intValue(), ((Number) result[1]).intValue()),

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/repository/UserRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/user/repository/UserRepository.java
@@ -1,9 +1,9 @@
 package com.mars.admin.domain.user.repository;
 
-import com.mars.admin.domain.user.enums.UserListSearchType;
 import com.mars.common.enums.oauth.OAuth2Provider;
 import com.mars.common.enums.user.UserStatus;
 import com.mars.common.model.user.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -62,4 +62,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
         @Param("searchType") String searchType,
         @Param("searchKeyword") String searchKeyword,
         Pageable pageable);
+
+    @Query("""
+    SELECT FUNCTION('YEAR', u.createdAt) AS year, FUNCTION('MONTH', u.createdAt) AS month, COUNT(u) AS userCount
+    FROM User u
+    WHERE u.createdAt >= :startDate AND u.createdAt < :endDate
+    GROUP BY FUNCTION('YEAR', u.createdAt), FUNCTION('MONTH', u.createdAt)
+    ORDER BY year, month
+""")
+    List<Object[]> getMonthRegisterCount(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -45,8 +45,9 @@ class ChartServiceTest extends IntegrationTestSupport {
     @Test
     void getMonthPostCountTotals() {
         // given
-        User user = createUser();
+        int month = 12;
 
+        User user = createUser();
         userRepository.save(user);
 
         List<Community> posts = new ArrayList<>();
@@ -58,7 +59,7 @@ class ChartServiceTest extends IntegrationTestSupport {
         String currentMonthKey = YearMonth.now().format(DateTimeFormatter.ofPattern("MM")) + "월";
 
         // when
-        List<MonthPostCountDto> totals = chartService.getPostMonthCountTotals();
+        List<MonthPostCountDto> totals = chartService.getPostMonthCountTotals(month - 1);
 
         // then
         assertThat(totals.size()).isEqualTo(1);

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -3,6 +3,7 @@ package com.mars.admin.domain.dashboard.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
+import com.mars.admin.domain.dashboard.dto.MonthCommunityCountDto;
 import com.mars.admin.domain.user.repository.UserRepository;
 import com.mars.admin.domain.user.service.UserService;
 import com.mars.admin.support.IntegrationTestSupport;
@@ -12,7 +13,6 @@ import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,11 +58,11 @@ class ChartServiceTest extends IntegrationTestSupport {
         String currentMonthKey = YearMonth.now().format(DateTimeFormatter.ofPattern("MM")) + "월";
 
         // when
-        Map<String, Long> totals = chartService.getPostMonthCountTotals();
+        List<MonthCommunityCountDto> totals = chartService.getPostMonthCountTotals();
 
         // then
-        assertThat(totals.size()).isEqualTo(12);
-        assertThat(totals).containsKey(currentMonthKey);
-        assertThat(totals.get(currentMonthKey)).isEqualTo(5L);
+        assertThat(totals.size()).isEqualTo(1);
+        assertThat(totals.get(0).month()).contains(currentMonthKey);
+        assertThat(totals.get(0).count()).isEqualTo(5L);
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -58,7 +58,7 @@ class ChartServiceTest extends IntegrationTestSupport {
         String currentMonthKey = YearMonth.now().format(DateTimeFormatter.ofPattern("MM")) + "월";
 
         // when
-        List<MonthPostCountDto> totals = chartService.getMonthPostCountTotals();
+        List<MonthPostCountDto> totals = chartService.getPostMonthCountTotals();
 
         // then
         assertThat(totals.size()).isEqualTo(1);

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -45,8 +45,6 @@ class ChartServiceTest extends IntegrationTestSupport {
     @Test
     void getMonthPostCountTotals() {
         // given
-        int month = 12;
-
         User user = createUser();
         userRepository.save(user);
 
@@ -59,7 +57,7 @@ class ChartServiceTest extends IntegrationTestSupport {
         String currentMonthKey = YearMonth.now().format(DateTimeFormatter.ofPattern("MM")) + "월";
 
         // when
-        List<MonthPostCountDto> totals = chartService.getPostMonthCountTotals(month - 1);
+        List<MonthPostCountDto> totals = chartService.getPostMonthCountTotals();
 
         // then
         assertThat(totals.size()).isEqualTo(1);

--- a/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
+++ b/NangPaGo-api/NangPaGo-admin/src/test/java/com/mars/admin/domain/dashboard/service/ChartServiceTest.java
@@ -3,7 +3,7 @@ package com.mars.admin.domain.dashboard.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
-import com.mars.admin.domain.dashboard.dto.MonthCommunityCountDto;
+import com.mars.admin.domain.dashboard.dto.MonthPostCountDto;
 import com.mars.admin.domain.user.repository.UserRepository;
 import com.mars.admin.domain.user.service.UserService;
 import com.mars.admin.support.IntegrationTestSupport;
@@ -43,7 +43,7 @@ class ChartServiceTest extends IntegrationTestSupport {
 
     @DisplayName("이번 달 게시글 총합 수를 조회할 수 있다.")
     @Test
-    void getPostMonthCountTotals() {
+    void getMonthPostCountTotals() {
         // given
         User user = createUser();
 
@@ -58,7 +58,7 @@ class ChartServiceTest extends IntegrationTestSupport {
         String currentMonthKey = YearMonth.now().format(DateTimeFormatter.ofPattern("MM")) + "월";
 
         // when
-        List<MonthCommunityCountDto> totals = chartService.getPostMonthCountTotals();
+        List<MonthPostCountDto> totals = chartService.getMonthPostCountTotals();
 
         // then
         assertThat(totals.size()).isEqualTo(1);


### PR DESCRIPTION
## 개요
- feat : Admin - 월별 회원가입 카운트 조회 기능 추가
	- 월별 회원가입한 사용자의 "숫자"만 나타남
	<img src="https://github.com/user-attachments/assets/af657206-8e29-4a84-bf90-3c3f5c5e17c9" width="60%">

- Admin - dashboard 월별 통계 Dto 분리 및 "월"이 보이도록 수정
	- 숫자 뒤에 "월"까지 같이 보이도록 수정
	- 데이터가 없는 월(값이 0인 경우)도 그래프에 포함하여 표시
	  (연속적으로 데이터가 없는 월까지 포함하여 12개월을 모두 보여주고 있음..)
	<img src="https://github.com/user-attachments/assets/e118d614-124a-44bc-9292-599271b136bb" width="60%">

- Admin - 월별 회원가입 통계 그래프 디자인 개선
	- 테스트 코드에서 메서드명 수정(getMonthPostCountTotals -> getPostMonthCountTotals)
	- "월별 게시글 통계" 형식에 맞춰 데이터 표시하는 기능 수정
	- 막대바 색상 변경 및 라인차트 추가
	<img src="https://github.com/user-attachments/assets/21d2a851-9597-476e-ae29-f5a2dd8cb66b" width="60%">

- 추가 제안 및 의견 : 추후에 개선시킬 경우, 월별 **회원가입** 통계에서 총사용자수만 보여주는 막대바를 가입경로(구글/카카오/네이버) 3개의 색깔로 구분하여 **누적막대** 그래프로 보여주는건 어떨까요?
라인차트의 경우에는 가입 경로 3개의 변화를 그려주면 좋을 것 같다는 생각이 듭니다..!
<img src="https://github.com/user-attachments/assets/d8badb3a-490e-4ccf-ad50-8d49ad0d3a73" width="50%">


## PR 유형

- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).