### PR TITLE
[NPG-234] 내 냉장고(재료기반 레시피 조회)- 선택한 재료가 아닌 모든 재료로 조회되던 버그 수정

### DIFF
--- a/NangPaGo-client/src/hooks/useRefrigerator.js
+++ b/NangPaGo-client/src/hooks/useRefrigerator.js
@@ -37,7 +37,7 @@ export function useRefrigerator(recipeSize = 10) {
     if (location.pathname === '/refrigerator/recipe') {
       reFetchRefrigeratorRecipes();
     }
-  }, [location.pathname, ingredients]);
+  }, [ingredients]);
 
   useEffect(() => {
     syncLocalStorage();


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Api 중복 호출로 데이터가 덮어 씌워지던 버그였으며,
 주소 값이 바뀔 때 `useEffect`가 실행되던 부분을 삭제하여 수정했습니다.

해당 부분을 지우기전과 후의 로직을 설명으로 첨부합니다.
보여주는 코드 또한 이전에 있던 기존 코드입니다.

**기존 로직**
1. 재료를 선택 후 레시피를 조회한다.
2. 레시피 조회 이후 주소 값이 바뀌었기에 `1번코드` 실행 (`isMounted`가 `true`로 변경)
3. 이후 `2번 코드` 실행으로 재료 값이 변경되어 `1번코드` 실행 (`isMounted`가 `true`이기 때문에 `reFetchRefrigeratorRecipes()`실행)
4. 재료값이 초기화 된 상태에서 `reFetchRefrigeratorRecipes()`가 다시 실행되면서 모든 재료 기준으로 조회

**수정된 로직**
1. 재료를 선택 후 레시피를 조회한다.
2. 레시피 조회 이후  `2번 코드` 실행으로 재료 값이 변경되어 `1번코드` 실행 (isMounted가 true로 변경) (화면 내 변화X)


### 1번 코드
해당 코드에는 `주소가 변경`되었을 때와 `재료 값이 수정`되었을 때,
 `isMounted`를 확인 후`reFetchRefrigeratorRecipes()`를 호출하여 레시피를 다시 조회하도록 되어있습니다.

```
useEffect(() => {
  if (!isMounted.current) {
    isMounted.current = true;
    return;
  }
  if (location.pathname === '/refrigerator/recipe') {
    reFetchRefrigeratorRecipes();
  }
}, [location.pathname, ingredients]);
```

### 2번 코드
해당 코드는 기본적으로 처음 마운트될 때, 데이터를 가져오고 재료 체크상태를 false로 바꿉니다.
```
  useEffect(() => {
    fetchRefrigerator();
  }, []);
  
  const fetchRefrigerator = async () => {
  try {
    const data = await getRefrigerator();
    setIngredients(data.map((item) => ({ ...item, checked: false })));
  } catch (error) {
    handleApiError('Failed to fetch refrigerator data.', error);
    setIngredients([]);
  }
};
```

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).