### PR TITLE
[NPG-233] 이미지가 아닌 다른 종류의 확장자 파일 업로드가 불가능하게 수정

### DIFF
--- a/NangPaGo-client/src/components/common/Modal.jsx
+++ b/NangPaGo-client/src/components/common/Modal.jsx
@@ -29,7 +29,7 @@ function Modal({ isOpen, onClose, title, description, children, buttons }) {
       onClick={handleBackgroundClick}
     >
       <div
-        className="bg-white p-8 rounded-lg relative flex flex-col items-center max-w-[300px] w-[calc(100%-32px)]"
+        className="bg-white p-8 rounded-lg relative flex flex-col items-center max-w-[350px] w-[calc(100%-32px)]"
         onClick={(e) => e.stopPropagation()}
       >
         {title && (

--- a/NangPaGo-client/src/components/community/FileUpload.jsx
+++ b/NangPaGo-client/src/components/community/FileUpload.jsx
@@ -1,10 +1,28 @@
 import { IMAGE_STYLES } from '../../common/styles/Image';
 import { FaTimes } from 'react-icons/fa';
 
+const IMAGE_ALLOWED_EXTENSIONS = [
+  "jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "tiff", "tif", "bmp", "raw", "cr2", "nef", "arw", "dng", "rw2", "orf", "sr2"
+];
+
 function FileUpload({ file, onChange, imagePreview, onCancel }) {
   const handleCancel = (e) => {
     e.preventDefault();
     onCancel();
+  };
+
+  const handleFileChange = (e) => {
+    const selectedFile = e.target.files[0];
+
+    if (selectedFile) {
+      const fileExtension = selectedFile.name.split('.').pop().toLowerCase();
+      if (!IMAGE_ALLOWED_EXTENSIONS.includes(fileExtension)) {
+        alert('이미지 파일만 업로드 가능합니다.');
+        e.target.value = '';
+        return;
+      }
+      onChange(e);
+    }
   };
 
   return (
@@ -36,7 +54,7 @@ function FileUpload({ file, onChange, imagePreview, onCancel }) {
           type="file"
           accept="image/*"
           className="absolute inset-0 opacity-0 cursor-pointer"
-          onChange={onChange}
+          onChange={handleFileChange}
           key={file ? file.name : 'file-upload'}
         />
       </label>

--- a/NangPaGo-client/src/components/community/FileUpload.jsx
+++ b/NangPaGo-client/src/components/community/FileUpload.jsx
@@ -1,11 +1,14 @@
+import { useState } from 'react';
 import { IMAGE_STYLES } from '../../common/styles/Image';
 import { FaTimes } from 'react-icons/fa';
+import OnlyImageUploadModal from '../../components/modal/OnlyImageUploadModal';
 
 const IMAGE_ALLOWED_EXTENSIONS = [
   "jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "tiff", "tif", "bmp", "raw", "cr2", "nef", "arw", "dng", "rw2", "orf", "sr2"
 ];
 
 function FileUpload({ file, onChange, imagePreview, onCancel }) {
+  const [showOnlyImageUpload, setShowOnlyImageUpload] = useState(false);
   const handleCancel = (e) => {
     e.preventDefault();
     onCancel();
@@ -17,7 +20,7 @@ function FileUpload({ file, onChange, imagePreview, onCancel }) {
     if (selectedFile) {
       const fileExtension = selectedFile.name.split('.').pop().toLowerCase();
       if (!IMAGE_ALLOWED_EXTENSIONS.includes(fileExtension)) {
-        alert('이미지 파일만 업로드 가능합니다.');
+        setShowOnlyImageUpload(true);
         e.target.value = '';
         return;
       }
@@ -58,6 +61,11 @@ function FileUpload({ file, onChange, imagePreview, onCancel }) {
           key={file ? file.name : 'file-upload'}
         />
       </label>
+
+      <OnlyImageUploadModal
+        isOpen={showOnlyImageUpload}
+        onClose={() => setShowOnlyImageUpload(false)}
+      />
     </div>
   );
 }

--- a/NangPaGo-client/src/components/modal/OnlyImageUploadModal.jsx
+++ b/NangPaGo-client/src/components/modal/OnlyImageUploadModal.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Modal from '../common/Modal';
+
+function OnlyImageUploadModal({ isOpen, onClose }) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="이미지 파일만 업로드 가능합니다."
+      description=""
+      buttons={{
+        primary: {
+          text: '확인',
+          onClick: onClose
+        },
+      }}
+    >
+    </Modal>
+  );
+}
+
+export default OnlyImageUploadModal;

--- a/NangPaGo-client/src/pages/community/ModifyCommunity.jsx
+++ b/NangPaGo-client/src/pages/community/ModifyCommunity.jsx
@@ -191,7 +191,7 @@ function ModifyCommunity() {
             className="mr-2 w-4 h-4 appearance-none border border-text-400 rounded-md checked:bg-primary"
           />
           <label htmlFor="is-public" className="text-sm text-text-600">
-            비공개 (체크 시 로그인한 사용자만 볼 수 있습니다.)
+            비공개
           </label>
         </div>
         <p className={ERROR_STYLES.community}>{error}</p>


### PR DESCRIPTION
## 개요
- 수정 전 : 커뮤니티 & 유저 레시피 작성 시 이미지가 아닌 다른 종류의 파일(예: .xls, .pdf 등등)도 업로드 가능함

- 수정 후
	- 247d45f1eb5bc48ddccc9d42c495848ca6f6f52c : 이미지가 아닌 파일을 업로드하려고할 때, Block하는 기능 추가 (alert창으로 띄우기)
	<img src="https://github.com/user-attachments/assets/15922e89-9265-40d7-8f88-94bdc1e46d6c" width="60%">

	- 309ca136ad57355a728e14776595f5d49e2a2720 : alert 창을 모달 팝업으로 변경
	<img src="https://github.com/user-attachments/assets/a2650848-b303-4ad6-9925-85bca219e3d6" width="60%">


## PR 유형

- [X] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경


## PR Checklist

- [X] PR 제목을 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).