### PR TITLE
[NPG-241] 유저 알림 발행 포인트 추가

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityLikeController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityLikeController.java
@@ -28,7 +28,6 @@ public class CommunityLikeController {
     private final CommunityLikeService communityLikeService;
     private final CommunityLikeMessagePublisher communityLikeMessagePublisher;
     private final CommunityLikeSseService communityLikeSseService;
-    private final UserNotificationMessagePublisher userNotificationMessagePublisher;
 
     @Operation(summary = "게시물 좋아요 상태 조회")
     @AuthenticatedUser
@@ -45,12 +44,6 @@ public class CommunityLikeController {
         Long userId = AuthenticationHolder.getCurrentUserId();
 
         CommunityLikeResponseDto communityLikeResponseDto = communityLikeMessagePublisher.toggleLike(postId, userId);
-
-        userNotificationMessagePublisher.createUserNotification(
-            UserNotificationEventCode.COMMUNITY_LIKE,
-            userId,
-            postId
-        );
         return ResponseDto.of(communityLikeResponseDto);
     }
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityLikeController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/controller/CommunityLikeController.java
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RequiredArgsConstructor
 @Tag(name = "커뮤니티 좋아요 API", description = "커뮤니티 게시물 좋아요, SSE 구독")
-@RequestMapping("/api/community")
+@RequestMapping("/api/community/{id}/like")
 @RestController
 public class CommunityLikeController {
 
@@ -32,16 +32,16 @@ public class CommunityLikeController {
 
     @Operation(summary = "게시물 좋아요 상태 조회")
     @AuthenticatedUser
-    @GetMapping("/{id}/like/status")
-    public ResponseDto<Boolean> getCommunityLikeStatus(@PathVariable Long id) {
+    @GetMapping("/status")
+    public ResponseDto<Boolean> getCommunityLikeStatus(@PathVariable("id") Long id) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         return ResponseDto.of(communityLikeService.isLiked(id, userId));
     }
 
     @Operation(summary = "게시물 좋아요 토글 버튼")
     @AuthenticatedUser
-    @PostMapping("/{id}/like/toggle")
-    public ResponseDto<CommunityLikeResponseDto> toggleCommunityLike(@PathVariable Long postId) {
+    @PostMapping("/toggle")
+    public ResponseDto<CommunityLikeResponseDto> toggleCommunityLike(@PathVariable("id") Long postId) {
         Long userId = AuthenticationHolder.getCurrentUserId();
 
         CommunityLikeResponseDto communityLikeResponseDto = communityLikeMessagePublisher.toggleLike(postId, userId);
@@ -55,15 +55,15 @@ public class CommunityLikeController {
     }
 
     @Operation(summary = "게시물 좋아요 개수 조회")
-    @GetMapping("/{id}/like/count")
-    public ResponseDto<Long> getCommunityLikeCount(@PathVariable Long id) {
+    @GetMapping("/count")
+    public ResponseDto<Long> getCommunityLikeCount(@PathVariable("id") Long id) {
         long likeCount = communityLikeService.getLikeCount(id);
         return ResponseDto.of(likeCount);
     }
 
     @Operation(summary = "게시물 총 좋아요 개수 변경 SSE 이벤트 구독")
-    @GetMapping("/{id}/like/notification/subscribe")
-    public SseEmitter streamLikes(@PathVariable Long id) {
+    @GetMapping("/notification/subscribe")
+    public SseEmitter streamLikes(@PathVariable("id") Long id) {
         return communityLikeSseService.createEmitter(id);
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/message/like/CommunityLikeMessageConsumer.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/community/message/like/CommunityLikeMessageConsumer.java
@@ -4,7 +4,9 @@ import com.mars.app.domain.community.dto.like.CommunityLikeMessageDto;
 import com.mars.app.domain.community.event.CommunityLikeEvent;
 import com.mars.app.domain.community.repository.CommunityLikeRepository;
 import com.mars.app.domain.community.repository.CommunityRepository;
+import com.mars.app.domain.user.message.UserNotificationMessagePublisher;
 import com.mars.app.domain.user.repository.UserRepository;
+import com.mars.common.enums.user.UserNotificationEventCode;
 import com.mars.common.exception.NPGExceptionType;
 import com.mars.common.model.community.Community;
 import com.mars.common.model.community.CommunityLike;
@@ -23,6 +25,8 @@ public class CommunityLikeMessageConsumer {
     private final UserRepository userRepository;
 
     private final ApplicationEventPublisher sseEventPublisher;
+
+    private final UserNotificationMessagePublisher userNotificationMessagePublisher;
 
     @Transactional
     @RabbitListener(queues = "#{@communityLikeQueue.name}")
@@ -49,6 +53,11 @@ public class CommunityLikeMessageConsumer {
 
     private boolean addLike(User user, Community community) {
         communityLikeRepository.save(CommunityLike.of(user, community));
+        userNotificationMessagePublisher.createUserNotification(
+            UserNotificationEventCode.COMMUNITY_LIKE,
+            user.getId(),
+            community.getId()
+        );
         return true;
     }
 

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/controller/UserNotificationController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/controller/UserNotificationController.java
@@ -61,12 +61,4 @@ public class UserNotificationController {
         Long userId = AuthenticationHolder.getCurrentUserId();
         return ResponseDto.of(userNotificationService.getUnreadNotificationCount(userId));
     }
-
-    @Operation(summary = "알림 읽음 상태 업데이트")
-    @AuthenticatedUser
-    @PutMapping("/state/read")
-    public ResponseDto<UserNotificationCountResponseDto> updateNotificationState() {
-        Long userId = AuthenticationHolder.getCurrentUserId();
-        return ResponseDto.of(userNotificationService.markAsReadToAllNotification(userId));
-    }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/message/UserNotificationMessageConsumer.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/message/UserNotificationMessageConsumer.java
@@ -24,10 +24,10 @@ public class UserNotificationMessageConsumer {
 
     @Transactional
     @RabbitListener(queues = "#{@userNotificationQueue.name}")
-    public void processUserNotificationMessage(UserNotificationMessageDto userNotificationMessageDto) {
-        Long receiverId = findReceiverId(userNotificationMessageDto);
-        saveAndPublishNotification(userNotificationMessageDto, receiverId);
-        publishUserNotificationEvent(userNotificationMessageDto, receiverId);
+    public void processUserNotificationMessage(UserNotificationMessageDto messageDto) {
+        Long receiverId = findReceiverId(messageDto);
+        saveAndPublishNotification(messageDto, receiverId);
+        publishUserNotificationEvent(messageDto, receiverId);
     }
 
     private Long findReceiverId(UserNotificationMessageDto dto) {

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/repository/UserNotificationRepository.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/repository/UserNotificationRepository.java
@@ -23,7 +23,7 @@ public interface UserNotificationRepository extends MongoRepository<UserNotifica
     @Query(value = "{ 'userId': ?0, 'isRead': false }", count = true)
     long countByUserIdAndIsReadFalse(Long userId);
 
-    @Query(value = "{ 'userId': ?0, 'isRead': false }", delete = false, count = true)
+    @Query(value = "{ 'userId': ?0, 'isRead': false }", delete = false)
     @Update("{ '$set': { 'isRead': true }}")
-    long markAllAsReadByUserId(Long userId);
+    void markAllAsReadByUserId(Long userId);
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserNotificationService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user/service/UserNotificationService.java
@@ -18,10 +18,14 @@ public class UserNotificationService {
 
     private final UserNotificationRepository userNotificationRepository;
 
+    @Transactional
     public List<UserNotificationResponseDto> getRecentNotifications(Long userId) {
         LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(NOTIFICATION_RETENTION_DAYS);
         List<UserNotification> notificationsSince = userNotificationRepository.findNotificationsSince(fourteenDaysAgo,
             userId);
+
+        // 리스트 조회와 동시에 읽음 처리
+        userNotificationRepository.markAllAsReadByUserId(userId);
 
         return notificationsSince.stream()
             .map(UserNotificationResponseDto::from)
@@ -32,14 +36,6 @@ public class UserNotificationService {
         long countIsReadFalse = userNotificationRepository.countByUserIdAndIsReadFalse(userId);
         return UserNotificationCountResponseDto.builder()
             .count(countIsReadFalse)
-            .build();
-    }
-
-    @Transactional
-    public UserNotificationCountResponseDto markAsReadToAllNotification(Long userId) {
-        long countUpdated = userNotificationRepository.markAllAsReadByUserId(userId);
-        return UserNotificationCountResponseDto.builder()
-            .count(countUpdated)
             .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/controller/UserRecipeLikeController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/controller/UserRecipeLikeController.java
@@ -2,9 +2,11 @@ package com.mars.app.domain.user_recipe.controller;
 
 import com.mars.app.aop.auth.AuthenticatedUser;
 import com.mars.app.component.auth.AuthenticationHolder;
+import com.mars.app.domain.user.message.UserNotificationMessagePublisher;
 import com.mars.common.dto.ResponseDto;
 import com.mars.app.domain.user_recipe.dto.UserRecipeLikeResponseDto;
 import com.mars.app.domain.user_recipe.service.UserRecipeLikeService;
+import com.mars.common.enums.user.UserNotificationEventCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,30 +15,38 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Tag(name = "유저 커뮤니티 API", description = "유저 커뮤니티 게시물 좋아요 관련 API")
 @RestController
-@RequestMapping("/api/user-recipe")
+@RequestMapping("/api/user-recipe/{id}/like")
 public class UserRecipeLikeController {
 
     private final UserRecipeLikeService userRecipeLikeService;
+    private final UserNotificationMessagePublisher userNotificationMessagePublisher;
 
     @Operation(summary = "게시물 좋아요 상태 조회")
     @AuthenticatedUser
-    @GetMapping("/{id}/like/status")
-    public ResponseDto<Boolean> getUserCommunityLikeStatus(@PathVariable Long id) {
+    @GetMapping("/status")
+    public ResponseDto<Boolean> getUserCommunityLikeStatus(@PathVariable("id") Long id) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         return ResponseDto.of(userRecipeLikeService.isLiked(id, userId));
     }
 
     @Operation(summary = "게시물 좋아요 토글")
     @AuthenticatedUser
-    @PostMapping("/{id}/like/toggle")
-    public ResponseDto<UserRecipeLikeResponseDto> toggleUserCommunityLike(@PathVariable Long id) {
+    @PostMapping("/toggle")
+    public ResponseDto<UserRecipeLikeResponseDto> toggleUserCommunityLike(@PathVariable("id") Long postId) {
         Long userId = AuthenticationHolder.getCurrentUserId();
-        return ResponseDto.of(userRecipeLikeService.toggleLike(id, userId));
+
+        UserRecipeLikeResponseDto userRecipeLikeResponseDto = userRecipeLikeService.toggleLike(postId, userId);
+        userNotificationMessagePublisher.createUserNotification(
+            UserNotificationEventCode.USER_RECIPE_LIKE,
+            userId,
+            postId
+        );
+        return ResponseDto.of(userRecipeLikeResponseDto);
     }
 
     @Operation(summary = "게시물 좋아요 개수 조회")
-    @GetMapping("/{id}/like/count")
-    public ResponseDto<Long> getUserCommunityLikeCount(@PathVariable Long id) {
+    @GetMapping("/count")
+    public ResponseDto<Long> getUserCommunityLikeCount(@PathVariable("id") Long id) {
         long likeCount = userRecipeLikeService.getLikeCount(id);
         return ResponseDto.of(likeCount);
     }

--- a/NangPaGo-client/src/api/notification.js
+++ b/NangPaGo-client/src/api/notification.js
@@ -9,13 +9,3 @@ export async function getNotificationList() {
     throw error;
   }
 }
-
-export async function markNotificationsAsRead() {
-  try {
-    const response = await axiosInstance.put('/api/user/notification/state/read');
-    return response.data.data;
-  } catch (error) {
-    console.error('알림 읽음 처리 실패:', error);
-    throw error;
-  }
-}

--- a/NangPaGo-client/src/components/layout/header/ProfileDropdown.jsx
+++ b/NangPaGo-client/src/components/layout/header/ProfileDropdown.jsx
@@ -4,7 +4,7 @@ import { HEADER_STYLES } from '../../../common/styles/Header';
 import { BiChevronLeft } from "react-icons/bi";
 import LogoutModal from '../../modal/LogoutModal';
 import { FaRegUser, FaSignOutAlt, FaRegBell } from 'react-icons/fa';
-import { getNotificationList, markNotificationsAsRead } from '../../../api/notification';
+import { getNotificationList } from '../../../api/notification';
 
 const ProfileDropdown = ({
   isActive,
@@ -112,7 +112,6 @@ const ProfileDropdown = ({
         {notificationOpen && (
           <NotificationPanel
             onBack={handleBackClick}
-            notificationCount={notificationCount}
             notifications={notifications}
             onNotificationsRead={onNotificationsRead}
           />
@@ -167,15 +166,10 @@ const DropdownMenu = ({ notificationCount, onNicknameClick, onMyPageClick, onLog
   </DropdownContainer>
 );
 
-const NotificationPanel = ({ onBack, notificationCount, notifications, onNotificationsRead }) => {
+const NotificationPanel = ({ onBack, notifications, onNotificationsRead }) => {
   useEffect(() => {
     const markAsRead = async () => {
-      try {
-        await markNotificationsAsRead();
-        onNotificationsRead();
-      } catch (error) {
-        console.error('Failed to mark notifications as read:', error);
-      }
+      onNotificationsRead();  
     };
 
     if (notifications.length > 0) {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 누락되어 있던 '커뮤니티 게시글 좋아요', '유저 레시피 좋아요', '유저 레시피 댓글' 에 대한 유저 알림 추가
- 유저가 알림을 조회할 때 읽음 처리도 동시에 하도록 변경함.

## PR 유형

- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).