### PR TITLE
[NPG-213] 기존 레시피 이미지 압축 및 리사이징 

### DIFF
--- a/NangPaGo-api/NangPaGo-app/build.gradle
+++ b/NangPaGo-api/NangPaGo-app/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'net.coobird:thumbnailator:0.4.18'
+
 
     testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/security/SecurityConfig.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
     private static final String[] WHITE_LIST_RECIPE = {
         "/api/recipe/search",
         "/api/recipe/{id}",
+        "/api/image/optimize",
         "/api/recipe/{id}/comment",
         "/api/recipe/{id}/comment/count",
         "/api/recipe/{id}/like/count",

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/controller/FirebaseStorageController.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/controller/FirebaseStorageController.java
@@ -1,16 +1,19 @@
 package com.mars.app.domain.firebase.controller;
 
+import com.mars.app.domain.firebase.service.ImageOptimizationService;
 import com.mars.common.dto.ResponseDto;
 import com.mars.app.domain.firebase.service.FirebaseStorageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RequiredArgsConstructor
 @Tag(name = "이미지 업로드 API", description = "Firebase Storage에 이미지 업로드 API")
 @RequestMapping("/api/image")
@@ -18,11 +21,17 @@ import org.springframework.web.multipart.MultipartFile;
 public class FirebaseStorageController {
 
     private final FirebaseStorageService firebaseStorageService;
+    private final ImageOptimizationService imageOptimizationService;
 
     @PostMapping("/upload")
     @Operation(summary = "이미지 업로드", description = "Firebase Storage에 이미지를 업로드합니다.")
     public ResponseDto<String> uploadFile(@RequestPart("file") MultipartFile file) {
         String fileUrl = firebaseStorageService.uploadFile(file);
         return ResponseDto.of(fileUrl, "이미지 업로드 성공");
+    }
+
+    @PostMapping("/optimize")
+    public ResponseDto<String> optimizeImages() {
+        return ResponseDto.of(imageOptimizationService.optimizeAndUpdateImages());
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/service/FirebaseOptimizeService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/service/FirebaseOptimizeService.java
@@ -1,0 +1,129 @@
+package com.mars.app.domain.firebase.service;
+
+import static com.google.cloud.storage.Acl.Role.READER;
+import static com.mars.common.exception.NPGExceptionType.SERVER_ERROR_FILE_NOT_FOUND;
+import static com.mars.common.exception.NPGExceptionType.SERVER_ERROR_IMAGE_UPLOAD;
+
+import com.google.cloud.storage.Acl;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FirebaseOptimizeService {
+
+    private final Bucket bucket;
+
+    private static final int TARGET_WIDTH = 960;
+    private static final int TARGET_HEIGHT = 630;
+    private static final float IMAGE_QUALITY = 0.8f;
+
+    private static final String ORIGINAL_PATH = "original/";
+    private static final String OPTIMIZED_PATH = "optimized/";
+    private static final String IMAGE_URL_PREFIX = "https://storage.googleapis.com/";
+    private static final String IMAGE_CONTENT_TYPE = "image/";
+    private static final String VALID_IMAGE_EXTENSIONS = "jpg|jpeg|png|webp|gif";
+    private static final String URL_CLEANUP_REGEX = "^(https?://.*/)?" + ORIGINAL_PATH;
+
+    public String optimizeAndUpload(String originalFileUrl) {
+        String originalFileName = extractFileNameFromUrl(originalFileUrl);
+        Blob oldBlob = getBlobFromStorage(originalFileName);
+        byte[] imageBytes = oldBlob.getContent();
+
+        BufferedImage image = loadImage(imageBytes, originalFileName);
+        String extension = getFileExtension(originalFileName);
+        String newFileName = OPTIMIZED_PATH + originalFileName.replaceFirst("^" + ORIGINAL_PATH, "");
+
+        if (isSmallImage(image)) {
+            return saveAndReturnUrl(newFileName, imageBytes, extension);
+        }
+
+        byte[] optimizedImage = optimizeImage(image, extension);
+        return saveAndReturnUrl(newFileName, optimizedImage, extension);
+    }
+
+    private Blob getBlobFromStorage(String fileName) {
+        Blob blob = bucket.get(fileName);
+        validateBlobExists(blob, fileName);
+        return blob;
+    }
+
+    private String saveAndReturnUrl(String fileName, byte[] data, String extension) {
+        saveToStorage(fileName, data, extension);
+        return generateFileUrl(fileName);
+    }
+
+    private void saveToStorage(String fileName, byte[] data, String extension) {
+        Blob blob = bucket.create(fileName, data, IMAGE_CONTENT_TYPE + extension);
+        blob.createAcl(Acl.of(Acl.User.ofAllUsers(), READER));
+    }
+
+    private BufferedImage loadImage(byte[] imageBytes, String fileName) {
+        try (InputStream inputStream = new ByteArrayInputStream(imageBytes)) {
+            BufferedImage image = ImageIO.read(inputStream);
+            if (image == null) {
+                throw SERVER_ERROR_IMAGE_UPLOAD.of("이미지를 불러오는 중 오류 발생");
+            }
+            return image;
+        } catch (IOException e) {
+            throw SERVER_ERROR_IMAGE_UPLOAD.of("이미지를 불러오는 중 오류 발생");
+        }
+    }
+
+    private byte[] optimizeImage(BufferedImage image, String extension) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Thumbnails.of(image)
+                .size(TARGET_WIDTH, TARGET_HEIGHT)
+                .outputQuality(IMAGE_QUALITY)
+                .outputFormat(extension)
+                .toOutputStream(outputStream);
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw SERVER_ERROR_IMAGE_UPLOAD.of("이미지 최적화 중 오류 발생");
+        }
+    }
+
+    private boolean isSmallImage(BufferedImage image) {
+        return image.getWidth() <= TARGET_WIDTH && image.getHeight() <= TARGET_HEIGHT;
+    }
+
+    private String extractFileNameFromUrl(String fileUrl) {
+        return fileUrl.replaceAll(URL_CLEANUP_REGEX, ORIGINAL_PATH);
+    }
+
+    private String getFileExtension(String fileName) {
+        return Optional.ofNullable(fileName)
+            .filter(f -> f.contains("."))
+            .map(f -> f.substring(f.lastIndexOf('.') + 1).toLowerCase())
+            .filter(this::isValidImageExtension)
+            .orElse("jpg");
+    }
+
+    private boolean isValidImageExtension(String extension) {
+        return extension.matches(VALID_IMAGE_EXTENSIONS);
+    }
+
+    private String generateFileUrl(String fileName) {
+        return IMAGE_URL_PREFIX + bucket.getName() + "/" + fileName;
+    }
+
+    private void validateBlobExists(Blob blob, String fileName) {
+        if (isInvalidBlob(blob)) {
+            throw SERVER_ERROR_FILE_NOT_FOUND.of("Firebase Storage에서 파일을 찾을 수 없습니다. ");
+        }
+    }
+
+    private boolean isInvalidBlob(Blob blob) {
+        return blob == null || blob.getContent() == null;
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/service/FirebaseStorageService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/service/FirebaseStorageService.java
@@ -1,31 +1,92 @@
 package com.mars.app.domain.firebase.service;
 
+import static com.mars.common.exception.NPGExceptionType.SERVER_ERROR_IMAGE_UPLOAD;
+
 import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
-import com.mars.common.exception.NPGExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class FirebaseStorageService {
 
     private final Bucket bucket;
 
-    public String uploadFile(MultipartFile file) {
-        try {
-            String fileName = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
-            Blob blob = bucket.create(fileName, file.getBytes(), file.getContentType());
-            blob.createAcl(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
+    private static final String ORIGINAL_PATH = "original/";
+    private static final String IMAGE_URL_PREFIX = "https://storage.googleapis.com/";
+    private static final String IMAGE_CONTENT_TYPE = "image/";
+    public static final String DEFAULT_EXTENSION = "jpg";
+    private static final Set<String> VALID_IMAGE_EXTENSIONS = Set.of("jpg", "jpeg", "png", "webp", "gif");
 
-            return String.format("https://storage.googleapis.com/%s/%s", bucket.getName(), fileName);
-        } catch (IOException e) {
-            throw NPGExceptionType.SERVER_ERROR_IMAGE_UPLOAD.of();
-        }
+    public String uploadFile(MultipartFile file) {
+        return uploadToFirebase(
+            getFileBytes(file),
+            generateUniqueFileName(file.getOriginalFilename()),
+            file.getContentType()
+        );
+    }
+
+    public String uploadOriginalFile(byte[] imageBytes, String originalFileUrl) {
+        return uploadToFirebase(
+            imageBytes,
+            ORIGINAL_PATH + generateUniqueFileName(originalFileUrl),
+            IMAGE_CONTENT_TYPE + getValidFileExtension(originalFileUrl)
+        );
+    }
+
+    private byte[] getFileBytes(MultipartFile file) {
+        return Optional.ofNullable(file)
+            .map(f -> {
+                try {
+                    return f.getBytes();
+                } catch (IOException e) {
+                    throw SERVER_ERROR_IMAGE_UPLOAD.of("파일을 읽을 수 없습니다.");
+                }
+            })
+            .orElseThrow(() -> SERVER_ERROR_IMAGE_UPLOAD.of("파일이 비어 있습니다."));
+    }
+
+    private String uploadToFirebase(byte[] fileData, String fileName, String contentType) {
+        return Optional.ofNullable(bucket.create(fileName, fileData, contentType))
+            .map(blob -> {
+                blob.createAcl(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
+                return generateFileUrl(fileName);
+            })
+            .orElseThrow(() -> SERVER_ERROR_IMAGE_UPLOAD.of("Firebase Storage 업로드 실패"));
+    }
+
+    private String generateUniqueFileName(String originalFilename) {
+        return UUID.randomUUID() + "_" + extractFileName(originalFilename);
+    }
+
+    private String getValidFileExtension(String fileName) {
+        return Optional.ofNullable(extractFileExtension(fileName))
+            .filter(VALID_IMAGE_EXTENSIONS::contains)
+            .orElse(DEFAULT_EXTENSION);
+    }
+
+    private String generateFileUrl(String fileName) {
+        return IMAGE_URL_PREFIX + bucket.getName() + "/" + fileName;
+    }
+
+    private String extractFileExtension(String fileName) {
+        return Optional.ofNullable(fileName)
+            .filter(f -> f.contains("."))
+            .map(f -> f.substring(f.lastIndexOf('.') + 1))
+            .orElse(null);
+    }
+
+    private String extractFileName(String fileName) {
+        return Optional.ofNullable(fileName)
+            .map(f -> f.substring(f.lastIndexOf('/') + 1))
+            .orElse(UUID.randomUUID().toString());
     }
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/service/ImageOptimizationService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/firebase/service/ImageOptimizationService.java
@@ -1,0 +1,81 @@
+package com.mars.app.domain.firebase.service;
+
+import com.mars.app.domain.recipe.repository.RecipeRepository;
+import com.mars.common.model.recipe.Recipe;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class ImageOptimizationService {
+
+    private final RecipeRepository recipeRepository;
+    private final FirebaseOptimizeService firebaseOptimizeService;
+    private final FirebaseStorageService firebaseStorageService;
+
+    private static final int BATCH_SIZE = 100;
+
+    @Value("${FIREBASE_CONFIGURATION_FILE}")
+    private String fallbackImageUrl;
+
+    @Transactional
+    public String optimizeAndUpdateImages() {
+        try {
+            IntStream.iterate(0, page -> page + 1)
+                .mapToObj(page -> recipeRepository.findAll(PageRequest.of(page, BATCH_SIZE)))
+                .takeWhile(Page::hasContent)
+                .flatMap(Page::stream)
+                .forEach(this::optimizeImageWithFallback);
+
+            return "이미지 최적화 및 업로드 완료";
+        } catch (Exception e) {
+            return "오류 발생: " + e.getMessage();
+        }
+    }
+
+    private void optimizeImageWithFallback(Recipe image) {
+        try {
+            optimizeImage(image);
+        } catch (IOException e) {
+            applyFallbackImage(image);
+        }
+    }
+
+    private void optimizeImage(Recipe image) throws IOException {
+        String optimizedImageUrl = uploadAndOptimizeImage(image.getMainImage());
+        updateDatabase(image, optimizedImageUrl);
+    }
+
+    private void applyFallbackImage(Recipe image) {
+        updateDatabase(image, fallbackImageUrl);
+    }
+
+    private String uploadAndOptimizeImage(String imageUrl) throws IOException {
+        byte[] imageBytes = downloadImage(imageUrl);
+        String uploadedUrl = firebaseStorageService.uploadOriginalFile(imageBytes, imageUrl);
+        return firebaseOptimizeService.optimizeAndUpload(uploadedUrl);
+    }
+
+    private byte[] downloadImage(String imageUrl) throws IOException {
+        try (InputStream in = new URL(imageUrl).openStream();
+            ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            in.transferTo(out);
+            return out.toByteArray();
+        }
+    }
+
+    private void updateDatabase(Recipe image, String newImageUrl) {
+        image.updateMainImage(newImageUrl);
+        recipeRepository.save(image);
+    }
+}

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/exception/NPGExceptionType.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/exception/NPGExceptionType.java
@@ -52,6 +52,7 @@ public enum NPGExceptionType {
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
     SERVER_ERROR_ELASTICSEARCH(HttpStatus.INTERNAL_SERVER_ERROR, "Elasticsearch 서버 에러"),
     SERVER_ERROR_IMAGE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 서버 오류"),
+    SERVER_ERROR_FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase Storage에서 파일을 찾을 수 없습니다."),
     SERVER_ERROR_RABBITMQ_CONNECTION(HttpStatus.INTERNAL_SERVER_ERROR, "RabbitMQ 연결에 실패했습니다."),
     SERVER_ERROR_SEND_LIKE_COUNT(HttpStatus.INTERNAL_SERVER_ERROR, "좋아요 수 전송 중 오류가 발생했습니다."),
     ;

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/recipe/ManualImage.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/recipe/ManualImage.java
@@ -18,4 +18,8 @@ public class ManualImage extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
+
+    public void updateImageUrl(String newImageUrl) {
+        this.imageUrl = newImageUrl;
+    }
 }

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/recipe/Recipe.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/recipe/Recipe.java
@@ -51,4 +51,8 @@ public class Recipe extends BaseEntity {
 
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecipeFavorite> favorites;
+
+    public void updateMainImage(String newImageUrl) {
+        this.mainImage = newImageUrl;
+    }
 }

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/userRecipe/UserRecipe.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/userRecipe/UserRecipe.java
@@ -1,6 +1,5 @@
 package com.mars.common.model.userRecipe;
 
-import com.mars.common.enums.comment.UserRecipeCommentStatus;
 import com.mars.common.enums.userRecipe.UserRecipeStatus;
 import com.mars.common.model.BaseEntity;
 import com.mars.common.model.comment.userRecipe.UserRecipeComment;


### PR DESCRIPTION
## 개요
- thumbnailator 의존성 추가 
      - 이미지(사진) 리사이즈 기능 제공 해주는 라이브러리
      - 이미지 사이즈 960 x 630 로 리사이징 -> 기준보다 작을 시에는 기존 크기 유지
      - 압축 80%
- 결과
<img width="536" alt="스크린샷 2025-02-10 오전 8 42 35" src="https://github.com/user-attachments/assets/deb95fa1-0d3b-4d5a-a1e7-34cad1549eda" />

- 앞으로 진행 할 것 (오늘 중으로 끝날 예정)
     - 현재 코드 흐름
          1. 기존 레시피 이미지를 조회
          2. 원본 이미지를 스토리지에 저장
          3. 이미지 최적화
          4. DB에 최적화된 이미지 정보 저장
     - 변경하고자 하는 방향
          1. 유저가 작성(등록)하거나 수정할 때 이미지를 자동으로 최적화
          2. 최적화된 이미지를 스토리지에 저장
          3. 동시에 DB에도 이미지 정보 저장
     - CDN 적용

- 논의 해볼만 한 것 (어디서 할 지: 백엔드 vs 프론트)
     - 이미지가 960×630보다 작은 경우, 원본 비율(비례)를 유지하면서 부족한 영역에 흰색 배경을 채워 
        최종적으로 960×630 사이즈로 맞추고자 합니다. 
예시: 원본이 500×400이라면 기존 크기를 유지하고 나머지 공간을 흰색으로 채운 결과물이 960×630이 되도록해서 스토리지에 저장

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).