### PR TITLE
[NO-ISSUE] BUGFIX - 유저레시피 작성 시, firefox 업로드 과정 500에러 발생

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/service/UserRecipeService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/service/UserRecipeService.java
@@ -113,7 +113,9 @@ public class UserRecipeService {
     }
 
     private String getUploadedImage(MultipartFile file, String existingImageUrl) {
-        firebaseStorageService.uploadNewFile(file);
+        if (file != null && !file.isEmpty()) {
+            return firebaseStorageService.uploadNewFile(file);
+        }
         return (existingImageUrl == null || existingImageUrl.isBlank())
             ? UserRecipeResponseDto.DEFAULT_IMAGE_URL
             : existingImageUrl;


### PR DESCRIPTION
## 개요
### BUGFIX: 유저레시피 작성 시, firefox 업로드 과정 500에러 발생
- 파일이 비어 있는지 체크한 후, 실제 파일이 업로드된 경우에만 해당 파일의 URL을 반환하고 그렇지 않으면 기본 이미지 URL을 반환하도록 수정

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).