### PR TITLE
[NO-ISSUE] 레시피 검색어 폰트 색상 변경 및 mainImage 사이즈 조정

### DIFF
--- a/NangPaGo-client/src/common/styles/Image.js
+++ b/NangPaGo-client/src/common/styles/Image.js
@@ -1,5 +1,5 @@
 export const IMAGE_STYLES = {
   imageList: 'w-full h-48 object-cover',
-  mainImage: 'w-full h-full rounded-md',
+  mainImage: 'w-full h-full rounded-md object-contain',
   detailImage: 'w-full h-full rounded-md',
 };

--- a/NangPaGo-client/src/components/community/Community.jsx
+++ b/NangPaGo-client/src/components/community/Community.jsx
@@ -1,5 +1,4 @@
-import { Fragment, useState, useEffect } from 'react';
-import { FaHeart, FaRegHeart } from 'react-icons/fa';
+import { Fragment } from 'react';
 import { IMAGE_STYLES } from '../../common/styles/Image';
 import PostStatusButton from '../button/PostStatusButton';
 
@@ -26,22 +25,21 @@ function Community({ post, data: community, isLoggedIn }) {
         <div className="mt-2 flex flex-col text-gray-500 text-xs">
           <span>
             <strong className="mr-2">{community.nickname}</strong>
-              <span>・ {formatDate(community.updatedAt)} </span>
+            <span>・ {formatDate(community.updatedAt)} </span>
           </span>
         </div>
       </div>
-      <div className="mt-4 px-4">
-        <img
-          src={community.imageUrl}
-          alt={community.title}
-          className={IMAGE_STYLES.mainImage}
-        />
+      <div className="w-full px-4">
+        <div className="w-full h-[70vh] overflow-hidden rounded-md flex justify-center items-center bg-gray-50">
+          <img
+            src={community.imageUrl}
+            alt={community.title}
+            className={IMAGE_STYLES.mainImage}
+          />
+        </div>
       </div>
       <div className="mt-2 flex items-center justify-between px-4">
-        <PostStatusButton
-          post={post}
-          isLoggedIn={isLoggedIn}
-        />
+        <PostStatusButton post={post} isLoggedIn={isLoggedIn} />
       </div>
       <div className="mt-4 px-4">
         <p className="text-gray-700 text-sm">

--- a/NangPaGo-client/src/components/layout/Footer.jsx
+++ b/NangPaGo-client/src/components/layout/Footer.jsx
@@ -8,8 +8,8 @@ function Footer() {
   const { version, fetchVersion } = versionFetcher();
 
   return (
-    <footer className="sticky bottom-0 right-0 bg-gray-100 p-4 flex flex-col items-center text-center md:flex-row md:justify-between">
-      <div className="flex gap-4 mb-2 md:mb-0 z-10">
+    <footer className="sticky z-50 bottom-0 right-0 bg-gray-100 p-4 flex flex-col items-center text-center md:flex-row md:justify-between">
+      <div className="flex gap-4 mb-2 md:mb-0">
         <a
           href={FOOTER.GITHUB_LINK}
           target="_blank"

--- a/NangPaGo-client/src/components/modal/BuildVersionModal.jsx
+++ b/NangPaGo-client/src/components/modal/BuildVersionModal.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Modal from '../common/Modal';
-import PropTypes from 'prop-types';
 
 function BuildVersionModal({ isOpen, onClose, version }) {
   return (

--- a/NangPaGo-client/src/components/recipe/Recipe.jsx
+++ b/NangPaGo-client/src/components/recipe/Recipe.jsx
@@ -61,7 +61,7 @@ function Recipe({ post, data: recipe, isLoggedIn }) {
           />
         </div>
         <div
-          className="md:w-1/2 md:flex md:flex-col md:justify-between"
+          className="md:w-5/12 md:flex md:flex-col md:justify-between md:ml-auto"
           ref={rightSectionRef}
         >
           <div>

--- a/NangPaGo-client/src/components/recipe/RecipeImage.jsx
+++ b/NangPaGo-client/src/components/recipe/RecipeImage.jsx
@@ -1,12 +1,13 @@
 function RecipeImage({ imageRef, mainImage, recipeName }) {
   return (
-    <div className="lg:w-1/2">
-      <img
-        ref={imageRef}
-        src={mainImage}
-        alt={recipeName}
-        className="w-full rounded-md"
-      />
+    <div className="lg:w-7/12 md:w-1/2">
+      <div className="rounded-md flex justify-center items-center aspect-square object-cover overflow-hidden bg-center">
+        <img className="w-full min-h-full rounded-md"
+             ref={imageRef}
+             src={mainImage}
+             alt={recipeName}
+        />
+      </div>
     </div>
   );
 }

--- a/NangPaGo-client/src/components/search/SearchBar.jsx
+++ b/NangPaGo-client/src/components/search/SearchBar.jsx
@@ -42,7 +42,7 @@ function SearchBar({ searchPath, searchTerm = '', onClear }) {
         className="relative flex items-center border border-primary rounded-md bg-white cursor-pointer"
         onClick={handleClick}
       >
-        <div className="w-full px-4 py-2 text-text-400">
+        <div className={`w-full px-4 py-2 ${searchTerm ? 'text-text-800 font-bold' : 'text-text-400'}`}>
           {searchTerm || '레시피 검색...'}
         </div>
         {getIcon()}

--- a/NangPaGo-client/src/components/userRecipe/UserRecipe.jsx
+++ b/NangPaGo-client/src/components/userRecipe/UserRecipe.jsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import usePostStatus from '../../hooks/usePostStatus';
 import CookingStepsSlider from '../userRecipe/CookingStepsSlider';
 import PostStatusButton from '../button/PostStatusButton';
 


### PR DESCRIPTION
## 개요
- 레시피 검색바 - searchTerm 폰트 색상 및 굵기 변경
   <img width="50%" alt="image" src="https://github.com/user-attachments/assets/d98ebdb3-a8c9-466a-837f-f433d54ca264" />

- 레시피상세 - 메인이미지
	- 수정 전: 각기 다른 이미지의 비율과 크기로 인해 mainImage의 크기가 각 레시피마다 조금씩 달랐음
	- 수정 후: `css: object-fit의 cover` 속성을 사용해 크기가 다르더라도 일정한 크기로 보여주도록 수정

| sm | md | lg |
|:---------------------:|:---------------------:|:---------------------:|
| <img width="70%" alt="image" src="https://github.com/user-attachments/assets/5aa55c73-e272-45a2-b617-587e121e5a60" /> | <img width="500%" alt="image" src="https://github.com/user-attachments/assets/66084afc-3334-4da1-9f53-512a8d9ec8a7" /> | <img width="70%" alt="image" src="https://github.com/user-attachments/assets/6d649211-4fcf-471a-91f9-673f0aca4de6" /> |

- 커뮤니티의 메인이미지
	- 기존 : 화면 너비를 기준으로 보여주고 있어서 세로 길이가 더 큰 사진이 경우 스크롤을 해서 봐야할 정도로 이미지 영역이 매우 컸음
	- 수정후 : 고정된 영역을 잡아놓고(bg-gray-50), 그 영역 안에서 contain 속성으로 가로세로 비율을 유지한 채로 줄인 다음 나머지 영역은 비워둠
<img width="30%" alt="image" src="https://github.com/user-attachments/assets/fa5eac8c-fc05-411a-8dfc-49f5119bd7c9" />     
<img width="30%" alt="image" src="https://github.com/user-attachments/assets/933e7757-a68b-44c7-bb80-7aebd82014ea" /> |


## PR 유형

- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).