### PR TITLE
[NPG-244] BUGFIX - 레시피 디테일 페이지 내 postStatus 중복 요청

### DIFF
--- a/NangPaGo-client/src/components/recipe/Recipe.jsx
+++ b/NangPaGo-client/src/components/recipe/Recipe.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import CookingStepsSlider from './CookingStepsSlider';
 import NutritionInfo from './NutritionInfo';
 import IngredientList from './IngredientList';
@@ -11,27 +11,28 @@ function Recipe({ post, data: recipe, isLoggedIn }) {
   const imageRef = useRef(null);
   const sliderRef = useRef(null);
 
+  const adjustImageHeight = useCallback(() => {
+    if (!rightSectionRef.current || !imageRef.current) {
+      return;
+    }
+
+    if (window.innerWidth > 767) {
+      const rightSectionHeight = rightSectionRef.current.offsetHeight;
+      imageRef.current.style.height = `${rightSectionHeight}px`;
+      imageRef.current.style.objectFit = 'cover';
+      return;
+    }
+
+    imageRef.current.style.height = 'auto';
+  }, []);
+
   useEffect(() => {
-    const adjustImageHeight = () => {
-      if (!rightSectionRef.current || !imageRef.current) {
-        return;
-      }
-
-      if (window.innerWidth > 767) {
-        const rightSectionHeight = rightSectionRef.current.offsetHeight;
-        imageRef.current.style.height = `${rightSectionHeight}px`;
-        imageRef.current.style.objectFit = 'cover';
-        return;
-      }
-
-      imageRef.current.style.height = 'auto';
-    };
-
     adjustImageHeight();
     window.addEventListener('resize', adjustImageHeight);
 
     return () => window.removeEventListener('resize', adjustImageHeight);
-  }, []);
+  }, [adjustImageHeight]);
+
 
   useEffect(() => {
     const resetSlider = () => {
@@ -53,13 +54,6 @@ function Recipe({ post, data: recipe, isLoggedIn }) {
           mainImage={recipe.mainImage}
           recipeName={recipe.name}
         />
-        <div className="mt-4 md:hidden">
-          <PostStatusButton
-            post={post}
-            isLoggedIn={isLoggedIn}
-            className="w-full"
-          />
-        </div>
         <div
           className="md:w-5/12 md:flex md:flex-col md:justify-between md:ml-auto"
           ref={rightSectionRef}
@@ -67,11 +61,8 @@ function Recipe({ post, data: recipe, isLoggedIn }) {
           <div>
             <div className="flex flex-col md:flex-row md:items-start md:justify-between mt-4 md:mt-0">
               <RecipeInfo recipe={recipe} />
-              <div className="hidden md:flex items-center gap-4">
-                <PostStatusButton
-                  post={post}
-                  isLoggedIn={isLoggedIn}
-                />
+              <div className="flex items-center gap-4 w-full mt-4 md:mt-0 md:w-auto">
+                <PostStatusButton post={post} isLoggedIn={isLoggedIn} className="w-full md:w-auto" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 개요
### BUGFIX: 레시피 디테일 페이지 내 postStatus 중복 요청
**Bug 내용**:
  - `Recipe` Detail 페이지가 두 번 렌더링됨.
  - `PostStatus` 버튼이 모바일/PC 뷰에서 각각 렌더링되었으나, `hidden` 처리만 되어 있어 실제로는 두 번 렌더링되고 있었음.

**변경 사항**:
  1. `useCallback`으로 변경하여, `Recipe` Detail 페이지를 한 번만 렌더링.
  2. `PostStatus` 버튼을 **단일 버튼**으로 통합하여 중복 렌더링 방지 및 모바일/데스크톱 뷰에 맞게 배치.
  3. 모바일 뷰에서 `PostStatus` 버튼을 레시피 제목과 태그 아래로 위치 조정하여 UI 개선.

| **변경 전 모바일 UI** | **변경 후 모바일 UI** |
|------------------|------------------|
| ![변경 전 이미지](https://github.com/user-attachments/assets/1083241f-d4c5-4219-95ec-5a2c405f7e9c)  | ![변경 후 이미지](https://github.com/user-attachments/assets/43ddb196-01cf-490d-9514-d05fd257d51a)  |


- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).