### PR TITLE
[NPG-251] 개선: 상단 Tab 메뉴 개선 및 내냉장고 리스트  header 변경

### DIFF
--- a/NangPaGo-client/src/components/layout/header/Header.jsx
+++ b/NangPaGo-client/src/components/layout/header/Header.jsx
@@ -3,12 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { logout } from '../../../slices/loginSlice.js';
 import axiosInstance from '../../../api/axiosInstance.js';
-import {
-  CgSmartHomeRefrigerator,
-  CgList,
-  CgProfile,
-  CgLogIn
-} from 'react-icons/cg';
+import { CgList, CgProfile, CgLogIn, CgHome } from 'react-icons/cg';
 import NavItem from './NavItem.jsx';
 import { BiBlanket } from 'react-icons/bi';
 import ProfileDropdown from './ProfileDropdown.jsx';
@@ -130,15 +125,15 @@ function Header({ isBlocked = false }) {
           />
         </div>
         <div className={HEADER_STYLES.navContainer}>
+          <NavItem
+            to="/"
+            isActive={location.pathname === '/'}
+            label="추천 레시피"
+            Icon={CgHome}
+            onClick={() => handleLinkClick('/')}
+          />
           {loginState.isLoggedIn && (
             <>
-            <NavItem
-              to="/refrigerator"
-              isActive={isActive('/refrigerator')}
-              label="냉장고"
-              Icon={CgSmartHomeRefrigerator}
-              onClick={() => handleLinkClick('/refrigerator')}
-            />
             <NavItem
                 to="/user-recipe"
                 isActive={isActive('/user-recipe')}
@@ -157,7 +152,7 @@ function Header({ isBlocked = false }) {
           />
           {loginState.isLoggedIn ? (
             <ProfileDropdown
-              isActive={isActive('/my-page')}
+              isActive={isActive('/my-page') || isActive('/refrigerator')}
               Icon={CgProfile}
               nickname={loginState.nickname}
               unreadCount={unreadCount}

--- a/NangPaGo-client/src/components/layout/header/NavItem.jsx
+++ b/NangPaGo-client/src/components/layout/header/NavItem.jsx
@@ -1,7 +1,11 @@
 import clsx from 'clsx';
 import { HEADER_STYLES } from '../../../common/styles/Header';
+import { useLocation } from 'react-router-dom';
 
-function NavItem({ to, isActive, label, Icon, onClick }) {
+function NavItem({ to, label, Icon, onClick }) {
+  const location = useLocation();
+  const isActive = location.pathname === to || location.pathname.startsWith(`${to}/`);
+
   return (
     <button
       onClick={() => onClick(to)}
@@ -14,12 +18,12 @@ function NavItem({ to, isActive, label, Icon, onClick }) {
         className={clsx(
           HEADER_STYLES.iconSize,
           HEADER_STYLES.buttonIcon,
-          isActive ? "text-primary" : "text-text-900 group-hover:text-primary"
+          isActive ? "text-primary" : "text-text-900"
         )}
       />
       <span className={clsx(
         HEADER_STYLES.buttonText,
-        isActive ? "text-primary" : "text-text-900 group-hover:text-primary"
+        isActive ? "text-primary" : "text-text-900"
       )}>
         {label}
       </span>

--- a/NangPaGo-client/src/components/layout/header/ProfileDropdown.jsx
+++ b/NangPaGo-client/src/components/layout/header/ProfileDropdown.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import clsx from 'clsx';
 import { HEADER_STYLES } from '../../../common/styles/Header';
 import LogoutModal from '../../modal/LogoutModal';
+import { CgSmartHomeRefrigerator } from 'react-icons/cg';
 import { FaRegUser, FaSignOutAlt, FaRegBell, FaRegTrashAlt, FaChevronLeft } from 'react-icons/fa';
 import { getNotificationList, deleteNotification } from '../../../api/notification';
 import { useNavigate } from 'react-router-dom';
@@ -98,7 +99,7 @@ const ProfileDropdown = ({
             HEADER_STYLES.buttonText,
             (isOpen || notificationOpen || isActive) ? "text-primary" : "text-text-900 group-hover:text-primary"
           )}>
-            프로필
+            MY
           </span>
         </button>
         {isOpen && !notificationOpen && (
@@ -106,6 +107,7 @@ const ProfileDropdown = ({
             notificationCount={notificationCount}
             onNicknameClick={handleNicknameClick}
             onMyPageClick={() => onLinkClick('/my-page')}
+            onRefrigeratorClick={() => onLinkClick('/refrigerator')}
             onLogout={handleLogoutClick}
           />
         )}
@@ -135,13 +137,19 @@ const DropdownContainer = ({ children, width = 'w-48' }) => (
   </div>
 );
 
-const DropdownMenu = ({ notificationCount, onNicknameClick, onMyPageClick, onLogout }) => (
+const DropdownMenu = ({
+  notificationCount,
+  onNicknameClick,
+  onMyPageClick,
+  onRefrigeratorClick,
+  onLogout,
+}) => (
   <DropdownContainer>
     <div className={HEADER_STYLES.dropdownContent}>
       <div className="group">
         <div className={HEADER_STYLES.arrowContainer}></div>
-        <button 
-          onClick={onNicknameClick} 
+        <button
+          onClick={onNicknameClick}
           className={clsx(HEADER_STYLES.dropdownItem, "font-medium")}
         >
           <FaRegBell />
@@ -156,6 +164,10 @@ const DropdownMenu = ({ notificationCount, onNicknameClick, onMyPageClick, onLog
       <button onClick={onMyPageClick} className={HEADER_STYLES.dropdownItem}>
         <FaRegUser />
         마이페이지
+      </button>
+      <button onClick={onRefrigeratorClick} className={HEADER_STYLES.dropdownItem}>
+        <CgSmartHomeRefrigerator />
+        내 냉장고
       </button>
       <div className="border-t border-gray-200">
         <button onClick={onLogout} className={clsx(HEADER_STYLES.dropdownItem, "text-red-400")}>

--- a/NangPaGo-client/src/pages/refrigerator/Refrigerator.jsx
+++ b/NangPaGo-client/src/pages/refrigerator/Refrigerator.jsx
@@ -5,6 +5,7 @@ import IngredientList from '../../components/refrigerator/IngredientList';
 import AddIngredientForm from '../../components/refrigerator/AddIngredientForm';
 import ContentCard from '../../components/common/ContentCard';
 import TopButton from '../../components/button/TopButton';
+import { PAGE_STYLES } from '../../common/styles/ListPage.js';
 
 function Refrigerator() {
   const {
@@ -46,9 +47,9 @@ function Refrigerator() {
           </>
         ) : (
           <>
-            <div className="mt-6 flex-grow flex flex-col">
-              <h2 className="text-lg font-medium mb-4">추천 레시피</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="flex-grow flex flex-col">
+              <div className={PAGE_STYLES.header}> 내 냉장고 재료 기반 - 추천 레시피 </div>
+              <div className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {recipes.length > 0 ? (
                   recipes.map((recipe) => (
                     <ContentCard

--- a/NangPaGo-client/src/pages/refrigerator/Refrigerator.jsx
+++ b/NangPaGo-client/src/pages/refrigerator/Refrigerator.jsx
@@ -48,7 +48,7 @@ function Refrigerator() {
         ) : (
           <>
             <div className="flex-grow flex flex-col">
-              <div className={PAGE_STYLES.header}> 내 냉장고 재료 기반 - 추천 레시피 </div>
+              <div className={PAGE_STYLES.header}> 추천 레시피 </div>
               <div className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {recipes.length > 0 ? (
                   recipes.map((recipe) => (


### PR DESCRIPTION
## 개요
- 개선 전
	- 현재 위치가 “레시피 추천” 페이지일 때, 노란불 들어와있는 메뉴가 아무것도 없는 상태
	
![스크린샷 2025-02-11 150629](https://github.com/user-attachments/assets/bd137c6c-c87e-468f-82a9-2e2b7b78aebd)

- 개선 후
	- “추천 레시피” 라는 이름의 아이콘을 하나 더 추가해서, 메인 레시피 페이지 및 레시피 상세 페이지일 때 노란불이 들어오도록 수정
	- “프로필”은 이름을 “MY” 로 바꾸기
	- “냉장고”는 프로필의 마이페이지 아래로 이동
	- 냉장고를 클릭시 MY의 활성화 상태가 유지되도록 함
	- 냉장고 재료를 선택하고 찾기 버튼을 누르면 이동하는 추천 레시피 페이지의 header 부분을 커뮤니티와 유저레시피와 통일감을 주기 위해 `className={PAGE_STYLES.header}`를 적용
	
	
![스크린샷 2025-02-11 145809](https://github.com/user-attachments/assets/5a0e5d61-6e6b-4af4-b12d-3c5eb6380196)
![스크린샷 2025-02-11 145909](https://github.com/user-attachments/assets/0c25a184-bc65-41ae-ba7b-87a7296b0a95)

## PR 유형

- [x] CSS 등 사용자 UI 디자인 변경

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).