### PR TITLE
[NPG-213] 레시피 이미지 수정 및 삭제시 스토리지에서 이미지 삭제 기능 추가

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/NangPaGoApplication.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/NangPaGoApplication.java
@@ -16,4 +16,3 @@ public class NangPaGoApplication {
 	}
 
 }	
-

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/service/UserRecipeService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/service/UserRecipeService.java
@@ -1,38 +1,66 @@
 package com.mars.app.domain.user_recipe.service;
 
-import static com.mars.common.exception.NPGExceptionType.*;
+import static com.mars.app.domain.user_recipe.dto.UserRecipeResponseDto.DEFAULT_IMAGE_URL;
+import static com.mars.common.enums.userRecipe.UserRecipeStatus.ACTIVE;
+import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_RECIPE;
+import static com.mars.common.exception.NPGExceptionType.NOT_FOUND_USER;
+import static com.mars.common.exception.NPGExceptionType.UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT;
+import static java.util.Objects.requireNonNullElse;
 
+import com.mars.app.domain.firebase.service.FirebaseStorageService;
+import com.mars.app.domain.user.repository.UserRepository;
 import com.mars.app.domain.user_recipe.dto.UserRecipeListResponseDto;
 import com.mars.app.domain.user_recipe.dto.UserRecipeRequestDto;
 import com.mars.app.domain.user_recipe.dto.UserRecipeResponseDto;
+import com.mars.app.domain.user_recipe.repository.UserRecipeCommentRepository;
 import com.mars.app.domain.user_recipe.repository.UserRecipeLikeRepository;
 import com.mars.app.domain.user_recipe.repository.UserRecipeRepository;
-import com.mars.app.domain.user_recipe.repository.UserRecipeCommentRepository;
-import com.mars.app.domain.firebase.service.FirebaseStorageService;
 import com.mars.common.dto.page.PageRequestVO;
 import com.mars.common.dto.page.PageResponseDto;
-import com.mars.common.enums.userRecipe.UserRecipeStatus;
 import com.mars.common.model.user.User;
-import com.mars.app.domain.user.repository.UserRepository;
-import com.mars.common.model.userRecipe.*;
+import com.mars.common.model.userRecipe.UserRecipe;
+import com.mars.common.model.userRecipe.UserRecipeIngredient;
+import com.mars.common.model.userRecipe.UserRecipeLike;
+import com.mars.common.model.userRecipe.UserRecipeManual;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class UserRecipeService {
 
+    public static final int DEFAULT_LIKE_COUNT = 0;
+    public static final int DEFAULT_COMMENT_COUNT = 0;
+    public static final int MIN_STEP = 0;
+    public static final int STEP_OFFSET = 1;
+
     private final UserRecipeRepository userRecipeRepository;
     private final UserRecipeLikeRepository userRecipeLikeRepository;
     private final UserRecipeCommentRepository userRecipeCommentRepository;
     private final UserRepository userRepository;
     private final FirebaseStorageService firebaseStorageService;
+
+    @Transactional
+    public UserRecipeResponseDto createUserRecipe(UserRecipeRequestDto requestDto,
+                                                    MultipartFile mainFile,
+                                                    List<MultipartFile> otherFiles,
+                                                    Long userId
+    ) {
+        User user = validateUser(userId);
+        UserRecipe recipe = createRecipe(requestDto, mainFile, user);
+
+        recipe.getIngredients().addAll(buildIngredients(requestDto, recipe));
+        recipe.getManuals().addAll(buildManuals(requestDto, otherFiles, recipe));
+
+        return UserRecipeResponseDto.of(userRecipeRepository.save(recipe), DEFAULT_LIKE_COUNT,
+            DEFAULT_COMMENT_COUNT, userId);
+    }
 
     public UserRecipeResponseDto getUserRecipeById(Long id, Long userId) {
         UserRecipe userRecipe = getUserRecipe(id);
@@ -48,22 +76,10 @@ public class UserRecipeService {
     }
 
     public PageResponseDto<UserRecipeListResponseDto> getPagedUserRecipes(Long userId, PageRequestVO pageRequestVO) {
-        List<UserRecipeLike> userRecipeLikes = getUserRecipeLikesBy(userId);
-
         return PageResponseDto.of(
             userRecipeRepository.findByIsPublicTrueOrUserIdAndRecipeStatus(userId, pageRequestVO.toPageable())
-                .map(userRecipe -> {
-                    int likeCount = userRecipeLikeRepository.countByUserRecipeId(userRecipe.getId());
-                    int commentCount = userRecipeCommentRepository.countByUserRecipeId(userRecipe.getId());
-                    return UserRecipeListResponseDto.of(userRecipe, likeCount, commentCount, userRecipeLikes);
-                })
+                .map(userRecipe -> toUserRecipeListResponseDto(userRecipe, userId))
         );
-    }
-
-    private List<UserRecipeLike> getUserRecipeLikesBy(Long userId) {
-        return userId.equals(User.ANONYMOUS_USER_ID)
-            ? new ArrayList<>()
-            : userRecipeLikeRepository.findUserRecipeLikesByUserId(userId);
     }
 
     @Transactional(readOnly = true)
@@ -78,73 +94,16 @@ public class UserRecipeService {
     }
 
     @Transactional
-    public void deleteUserRecipe(Long id, Long userId) {
-        UserRecipe userRecipe = getUserRecipe(id);
-        validateOwnership(userRecipe, userId);
-        userRecipe.softDelete();
-        userRecipeRepository.save(userRecipe);
-    }
+    public UserRecipeResponseDto updateUserRecipe(Long id, UserRecipeRequestDto requestDto, MultipartFile mainFile,
+                                                    List<MultipartFile> otherFiles, Long userId
+    ) {
+        UserRecipe recipe = getUserRecipe(id);
+        validateOwnership(recipe, userId);
 
-    private UserRecipe getUserRecipe(Long id) {
-        return userRecipeRepository.findByIdAndRecipeStatus(id, UserRecipeStatus.ACTIVE)
-            .orElseThrow(NOT_FOUND_RECIPE::of);
-    }
-
-    private void validateOwnership(UserRecipe userRecipe, Long userId) {
-        if (!userRecipe.getUser().getId().equals(userId)) {
-            throw UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT.of("게시물을 수정/삭제할 권한이 없습니다.");
-        }
-    }
-
-    @Transactional
-    public UserRecipeResponseDto createUserRecipe(UserRecipeRequestDto requestDto,
-                                                  MultipartFile mainFile,
-                                                  List<MultipartFile> otherFiles,
-                                                  Long userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
-
-        String mainImageUrl = getUploadedImage(mainFile, UserRecipeResponseDto.DEFAULT_IMAGE_URL);
-
-        UserRecipe recipe = userRecipeRepository.save(UserRecipe.builder()
-            .user(user)
-            .title(requestDto.getTitle())
-            .content(requestDto.getContent())
-            .mainImageUrl(mainImageUrl)
-            .isPublic(requestDto.isPublic())
-            .recipeStatus(UserRecipeStatus.ACTIVE)
-            .build());
-
-        recipe.getIngredients().addAll(buildIngredients(requestDto, recipe));
-        recipe.getManuals().addAll(buildManuals(requestDto, otherFiles, recipe));
-
-        return UserRecipeResponseDto.of(userRecipeRepository.save(recipe), 0, 0, userId);
-    }
-
-    private String getUploadedImage(MultipartFile file, String existingImageUrl) {
-        firebaseStorageService.uploadNewFile(file);
-        return (existingImageUrl == null || existingImageUrl.isBlank())
-            ? UserRecipeResponseDto.DEFAULT_IMAGE_URL
-            : existingImageUrl;
-    }
-
-    @Transactional
-    public UserRecipeResponseDto updateUserRecipe(Long id, UserRecipeRequestDto requestDto,
-        MultipartFile mainFile, List<MultipartFile> otherFiles,
-        Long userId) {
-        UserRecipe recipe = userRecipeRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("레시피를 찾을 수 없습니다."));
-
-        if (!recipe.getUser().getId().equals(userId)) {
-            throw new RuntimeException("권한이 없습니다.");
-        }
-
-        String previousMainImageUrl = recipe.getMainImageUrl();
-
-        String mainImageUrl = (mainFile != null && !mainFile.isEmpty()) ?
-            firebaseStorageService.updateFile(mainFile, previousMainImageUrl) : previousMainImageUrl;
-
+        String mainImageUrl = updateMainImage(mainFile, recipe.getMainImageUrl());
         recipe.update(requestDto.getTitle(), requestDto.getContent(), requestDto.isPublic(), mainImageUrl);
+
+        deleteUnusedManualImages(recipe, requestDto);
 
         recipe.getIngredients().clear();
         recipe.getIngredients().addAll(buildIngredients(requestDto, recipe));
@@ -152,7 +111,45 @@ public class UserRecipeService {
         recipe.getManuals().clear();
         recipe.getManuals().addAll(buildManuals(requestDto, otherFiles, recipe));
 
-        return UserRecipeResponseDto.of(userRecipeRepository.save(recipe), 0, 0, userId);
+        return UserRecipeResponseDto.of(userRecipeRepository.save(recipe), DEFAULT_LIKE_COUNT, DEFAULT_COMMENT_COUNT, userId);
+    }
+
+    @Transactional
+    public void deleteUserRecipe(Long id, Long userId) {
+        UserRecipe userRecipe = getUserRecipe(id);
+        validateOwnership(userRecipe, userId);
+
+        deleteImage(userRecipe.getMainImageUrl());
+
+        userRecipe.getManuals().stream()
+            .map(UserRecipeManual::getImageUrl)
+            .forEach(this::deleteImage);
+
+        userRecipe.softDelete();
+        userRecipeRepository.save(userRecipe);
+    }
+
+    private User validateUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> NOT_FOUND_USER.of("유저를 찾을 수 없습니다."));
+    }
+
+    private UserRecipe createRecipe(UserRecipeRequestDto requestDto, MultipartFile mainFile, User user) {
+        return userRecipeRepository.save(UserRecipe.builder()
+            .user(user)
+            .title(requestDto.getTitle())
+            .content(requestDto.getContent())
+            .mainImageUrl(getUploadedImage(mainFile, DEFAULT_IMAGE_URL))
+            .isPublic(requestDto.isPublic())
+            .recipeStatus(ACTIVE)
+            .build());
+    }
+
+    private String getUploadedImage(MultipartFile file, String existingImageUrl) {
+        if (file != null && !file.isEmpty()) {
+            return firebaseStorageService.uploadNewFile(file);
+        }
+        return requireNonNullElse(existingImageUrl, DEFAULT_IMAGE_URL);
     }
 
     private List<UserRecipeIngredient> buildIngredients(UserRecipeRequestDto dto, UserRecipe recipe) {
@@ -167,26 +164,80 @@ public class UserRecipeService {
 
     private List<UserRecipeManual> buildManuals(UserRecipeRequestDto dto, List<MultipartFile> otherFiles, UserRecipe recipe) {
         return dto.getManuals().stream()
-            .map(manualDto -> {
-                int stepValue = manualDto.getStep();
-                if (stepValue < 1) {
-                    stepValue = 1;
-                }
-                int index = stepValue - 1;
-
-                String imageUrl = getUploadedImage(
-                    (otherFiles != null && index < otherFiles.size()) ? otherFiles.get(index) : null,
-                    manualDto.getImageUrl()
-                );
-
-                return UserRecipeManual.builder()
-                    .userRecipe(recipe)
-                    .step(stepValue)
-                    .description(manualDto.getDescription())
-                    .imageUrl(imageUrl)
-                    .build();
-            })
+            .map(manualDto -> createManual(manualDto, getFileByIndex(otherFiles, manualDto.getStep()), recipe))
             .collect(Collectors.toList());
+    }
+
+    private UserRecipeManual createManual(UserRecipeRequestDto.ManualDto manualDto, MultipartFile file, UserRecipe recipe) {
+        return UserRecipeManual.builder()
+            .userRecipe(recipe)
+            .step(manualDto.getStep())
+            .description(manualDto.getDescription())
+            .imageUrl(getUploadedImage(file, manualDto.getImageUrl()))
+            .build();
+    }
+
+    private MultipartFile getFileByIndex(List<MultipartFile> files, int step) {
+        if (files == null || step <= MIN_STEP || step - STEP_OFFSET >= files.size()) {
+            return null;
+        }
+        return files.get(step - STEP_OFFSET);
+    }
+
+    private void validateOwnership(UserRecipe userRecipe, Long userId) {
+        if (!userRecipe.getUser().getId().equals(userId)) {
+            throw UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT.of("게시물을 수정/삭제할 권한이 없습니다.");
+        }
+    }
+
+    private UserRecipeListResponseDto toUserRecipeListResponseDto(UserRecipe userRecipe, Long userId) {
+        return UserRecipeListResponseDto.of(
+            userRecipe,
+            userRecipeLikeRepository.countByUserRecipeId(userRecipe.getId()),
+            userRecipeCommentRepository.countByUserRecipeId(userRecipe.getId()),
+            getUserRecipeLikesBy(userId)
+        );
+    }
+
+    private UserRecipe getUserRecipe(Long id) {
+        return userRecipeRepository.findByIdAndRecipeStatus(id, ACTIVE)
+            .orElseThrow(NOT_FOUND_RECIPE::of);
+    }
+
+    private List<UserRecipeLike> getUserRecipeLikesBy(Long userId) {
+        return userId.equals(User.ANONYMOUS_USER_ID)
+            ? new ArrayList<>() : userRecipeLikeRepository.findUserRecipeLikesByUserId(userId);
+    }
+
+    private String updateMainImage(MultipartFile mainFile, String previousMainImageUrl) {
+        if (mainFile != null && !mainFile.isEmpty()) {
+            return firebaseStorageService.updateFile(mainFile, previousMainImageUrl);
+        }
+        return previousMainImageUrl;
+    }
+
+    private void deleteImage(String imageUrl) {
+        if (imageUrl != null && !imageUrl.isBlank()) {
+            firebaseStorageService.deleteFileFromFirebase(imageUrl);
+        }
+    }
+
+    private void deleteUnusedManualImages(UserRecipe recipe, UserRecipeRequestDto requestDto) {
+        List<String> oldManualImages = recipe.getManuals().stream()
+            .map(UserRecipeManual::getImageUrl)
+            .collect(Collectors.toList());
+
+        List<String> newManualImages = requestDto.getManuals().stream()
+            .map(UserRecipeRequestDto.ManualDto::getImageUrl)
+            .collect(Collectors.toList());
+
+        oldManualImages.stream()
+            .filter(image -> isUnusedImage(image, newManualImages))
+            .forEach(firebaseStorageService::deleteFileFromFirebase);
+    }
+
+    private boolean isUnusedImage(String imageUrl, List<String> newImages) {
+        return imageUrl != null && !imageUrl.isBlank() && !newImages.contains(imageUrl);
     }
 
 }

--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/service/UserRecipeService.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/domain/user_recipe/service/UserRecipeService.java
@@ -122,9 +122,7 @@ public class UserRecipeService {
     }
 
     private String getUploadedImage(MultipartFile file, String existingImageUrl) {
-        if (file != null && !file.isEmpty()) {
-            return firebaseStorageService.uploadNewFile(file);
-        }
+        firebaseStorageService.uploadNewFile(file);
         return (existingImageUrl == null || existingImageUrl.isBlank())
             ? UserRecipeResponseDto.DEFAULT_IMAGE_URL
             : existingImageUrl;

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user_recipe/service/UserRecipeServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user_recipe/service/UserRecipeServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.multipart.MultipartFile;

--- a/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user_recipe/service/UserRecipeServiceTest.java
+++ b/NangPaGo-api/NangPaGo-app/src/test/java/com/mars/app/domain/user_recipe/service/UserRecipeServiceTest.java
@@ -2,8 +2,6 @@ package com.mars.app.domain.user_recipe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import com.mars.app.domain.firebase.service.FirebaseStorageService;
@@ -24,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.multipart.MultipartFile;
@@ -89,8 +86,6 @@ class UserRecipeServiceTest extends IntegrationTestSupport {
     @DisplayName("유저는 본인의 레시피를 수정할 수 있다.")
     @Test
     void updateUserRecipe() {
-        doNothing().when(firebaseStorageService).deleteFileFromFirebase(anyString());
-
         User user = User.builder().email("email@example.com").build();
         userRepository.save(user);
 

--- a/NangPaGo-client/src/components/profile/ProfileTabs.jsx
+++ b/NangPaGo-client/src/components/profile/ProfileTabs.jsx
@@ -1,7 +1,7 @@
 import {FaComment, FaFileAlt, FaHeart, FaStar} from 'react-icons/fa';
 
 const ProfileTabs = ({ activeTab, totalCounts, onTabChange }) => (
-  <div className="grid grid-cols-4 border-b">
+  <div className="grid grid-cols-4 border-b mb-4">
     {[
       {
         key: 'likes',

--- a/NangPaGo-client/src/components/profile/ProfileTabs.jsx
+++ b/NangPaGo-client/src/components/profile/ProfileTabs.jsx
@@ -1,7 +1,7 @@
 import {FaComment, FaFileAlt, FaHeart, FaStar} from 'react-icons/fa';
 
 const ProfileTabs = ({ activeTab, totalCounts, onTabChange }) => (
-  <div className="grid grid-cols-4 border-b mb-4">
+  <div className="grid grid-cols-4 border-b">
     {[
       {
         key: 'likes',


### PR DESCRIPTION
## 개요
- 기존에는 레시피 이미지 수정 및 삭제시 스토리지에서 이미지가 삭제가 안 되었음
    - 그 결과 불필요한 이미지들이 스토리지에 저장되어 용량차지 함
    - 스토리지에서 삭제 되도록 변경 
- 메서드 순서 변경

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).