### PR TITLE
[NPG-254] 레시피 검색 이후 일부 검색 조건에 따라 X버튼 기능이 안되던 버그 수정

### DIFF
--- a/NangPaGo-client/src/components/search/SearchBar.jsx
+++ b/NangPaGo-client/src/components/search/SearchBar.jsx
@@ -15,10 +15,6 @@ function SearchBar({ searchPath, searchTerm = '', onClear }) {
     if (!searchTerm) return;
 
     onClear();
-    navigate('/', {
-      state: { searchTerm: '' },
-      replace: true,
-    });
   };
 
   const getIcon = () => {

--- a/NangPaGo-client/src/pages/common/ListPage.jsx
+++ b/NangPaGo-client/src/pages/common/ListPage.jsx
@@ -81,7 +81,7 @@ function ListPage({ type }) {
   return (
     <div className={PAGE_STYLES.wrapper}>
       <Header />
-      <main className={PAGE_STYLES.body}>
+      <main key={searchTerm} className={PAGE_STYLES.body}>
         {renderHeader()}
         <ContentComponent
           activeTab={activeTab}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 레시피 검색 이후 X버튼 클릭 할 때, 일부 검색 조건에 따라 X버튼 기능이 안되던 버그를 수정했습니다.
    - 레시피를 검색 이후 나온 결과값이 1페이지 분량 일 경우 `URI`가 동일하여 `navigate`를 호출해도 리렌더링을 하지 않았음.
    - `navigate`를 사용하던 부분을 제거하고,  레시피를 보여주는 페이지 부분에 `key`를 설정하여 변경이 되면 강제 리렌더링 
    하도록 하였습니다.


## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).