### PR TITLE
[NPG-256] 어드민 페이지 일일 접속자 수 통계 구현

### DIFF
--- a/NangPaGo-admin/package-lock.json
+++ b/NangPaGo-admin/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.9",
+        "date-fns": "^4.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2396,6 +2397,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/NangPaGo-admin/package.json
+++ b/NangPaGo-admin/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/NangPaGo-admin/src/pages/Dashboard.jsx
+++ b/NangPaGo-admin/src/pages/Dashboard.jsx
@@ -154,13 +154,25 @@ export default function Dashboard() {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">일일 접속자 통계</h3>
-            <LineChart width={600} height={300} data={dailyUserStats}>
+            <LineChart width={600} height={300} data={dashboardData.dailyUserStats}>
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
+              <XAxis
+                dataKey="date"
+                tickFormatter={(date) => {
+                  const [month, day] = date.split('/');
+                  return `${month}/${day}`;
+                }}
+                interval={2}
+              />
               <YAxis />
-              <Tooltip />
+              <Tooltip
+                labelFormatter={(date) => {
+                  const [year, month, day] = date.split('-');
+                  return `${year}년 ${month}월 ${day}일`;
+                }}
+              />
               <Legend />
-              <Line type="monotone" dataKey="users" stroke="#4f46e5" />
+              <Line type="monotone" dataKey="users" name="접속자 수" stroke="#4f46e5" />
             </LineChart>
           </div>
         </div>

--- a/NangPaGo-admin/src/pages/Dashboard.jsx
+++ b/NangPaGo-admin/src/pages/Dashboard.jsx
@@ -1,36 +1,10 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line, ComposedChart, } from 'recharts';
-import { UserIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line, ComposedChart } from 'recharts';
+import { UserIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
 import { useState, useEffect } from 'react';
 import { getDashboardData } from '../api/total';
+import { format, eachDayOfInterval } from 'date-fns';
 
-// 더미 데이터
-const dailyUserStats = [
-  { name: '6/7', users: 0 },
-  { name: '6/8', users: 445 },
-  { name: '6/9', users: 389 },
-  { name: '6/10', users: 401 },
-  { name: '6/11', users: 367 },
-  { name: '6/12', users: 388 },
-  { name: '6/13', users: 152 },
-  { name: '6/14', users: 434 },
-  { name: '6/15', users: 456 },
-  { name: '6/16', users: 390 },
-  { name: '6/17', users: 387 },
-  { name: '6/18', users: 411 },
-  { name: '6/19', users: 394 },
-  { name: '6/20', users: 378 },
-  { name: '6/21', users: 402 },
-  { name: '6/22', users: 445 },
-  { name: '6/23', users: 467 },
-  { name: '6/24', users: 458 },
-  { name: '6/25', users: 398 },
-  { name: '6/26', users: 378 },
-  { name: '6/27', users: 401 },
-  { name: '6/28', users: 423 },
-  { name: '6/29', users: 445 },
-  { name: '6/30', users: 467 }
-];
-
+// 월 평균 로그인 통계 (더미 데이터)
 const monthlyAverageLoginStats = [
   { time: '00:00', avgLogins: 300 },
   { time: '01:00', avgLogins: 98 },
@@ -74,6 +48,35 @@ export default function Dashboard() {
 
     fetchData();
   }, []);
+
+  // 일별 사용자 통계 처리
+  const processedData = (() => {
+    if (!dashboardData.dailyUserStats || !dashboardData.dailyUserStats.length) return [];
+
+    const sortedData = [...dashboardData.dailyUserStats].sort(
+      (a, b) => new Date(a.date) - new Date(b.date)
+    );
+
+    const allDates = eachDayOfInterval({
+      start: new Date(sortedData[0].date),
+      end: new Date(sortedData[sortedData.length - 1].date),
+    }).map((date) => format(date, 'yyyy-MM-dd'));
+
+    const mappedData = allDates.map((date) => {
+      const found = sortedData.find((entry) => entry.date === date);
+      return found || { date, users: 0, unregisteredUsers: 0 };
+    });
+
+    const today = format(new Date(), 'yyyy-MM-dd');
+    if (mappedData[mappedData.length - 1].date !== today) {
+      mappedData.push({ date: today, users: 0, unregisteredUsers: 0 });
+    }
+
+    return mappedData;
+  })();
+
+  const today = new Date().toISOString().split('T')[0]
+  const todayData = dashboardData.dailyUserStats?.find((stat) => stat.date === today) || { users: 0, unregisteredUsers: 0 };
 
   return (
     <div className="p-6">
@@ -122,10 +125,11 @@ export default function Dashboard() {
 
       {/* 그래프 */}
       <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2">
+        {/* 월별 회원가입 통계 */}
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 회원가입통계</h3>
-            <ComposedChart width={600} height={300} data={dashboardData.monthlyRegisterData}>
+            <ComposedChart width={600} height={300} data={dashboardData.monthlyRegisterData || []}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
@@ -137,10 +141,11 @@ export default function Dashboard() {
           </div>
         </div>
 
+        {/* 월별 게시글 통계 */}
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월별 게시글 통계</h3>
-            <BarChart width={600} height={300} data={dashboardData.monthPostCountData}>
+            <BarChart width={600} height={300} data={dashboardData.monthPostCountData || []}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
@@ -151,32 +156,54 @@ export default function Dashboard() {
           </div>
         </div>
 
+        {/* 일일 접속자 통계 */}
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
-            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">일일 접속자 통계</h3>
-            <LineChart width={600} height={300} data={dashboardData.dailyUserStats}>
+            <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4 flex justify-between items-center w-[600px]">
+              <span>일일 접속자 수 통계</span>
+              <div className="flex items-center">
+                <div className="mr-4 flex items-center">
+                  <span className="text-xs font-medium text-gray-500">오늘의 로그인 사용자</span>
+                  <div className="ml-2 bg-red-100 text-red-800 rounded-full px-3 py-1 text-sm">
+                    {todayData.users ? `총 ${todayData.users}명` : '0명'}
+                  </div>
+                </div>
+                <div className="flex items-center">
+                  <span className="text-xs font-medium text-gray-500">비로그인 사용자</span>
+                  <div className="ml-2 bg-blue-100 text-blue-800 rounded-full px-3 py-1 text-sm">
+                    {todayData.unregisteredUsers ? `총 ${todayData.unregisteredUsers}명` : '0명'}
+                  </div>
+                </div>
+              </div>
+            </h3>
+            <LineChart width={600} height={300} data={processedData}>
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis
-                dataKey="date"
-                tickFormatter={(date) => {
-                  const [month, day] = date.split('/');
-                  return `${month}/${day}`;
-                }}
-                interval={2}
+              <XAxis dataKey="date" />
+              <YAxis
+                allowDecimals={false}
+                domain={[0, (dataMax) => Math.ceil(dataMax / 10) * 10]}
               />
-              <YAxis />
-              <Tooltip
-                labelFormatter={(date) => {
-                  const [year, month, day] = date.split('-');
-                  return `${year}년 ${month}월 ${day}일`;
-                }}
-              />
+              <Tooltip />
               <Legend />
-              <Line type="monotone" dataKey="users" name="접속자 수" stroke="#4f46e5" />
+              <Line
+                type="monotone"
+                dataKey="users"
+                name="로그인 사용자"
+                stroke="#FF0000"
+                dot={(data) => data.value === 0 ? false : true}
+              />
+              <Line
+                type="monotone"
+                dataKey="unregisteredUsers"
+                name="비로그인 사용자"
+                stroke="#0000FF"
+                dot={(data) => data.value === 0 ? false : true}
+              />
             </LineChart>
           </div>
         </div>
 
+        {/* 월 평균 시간대별 사용자 활동 현황 */}
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">월 평균 시간대별 사용자 활동 현황</h3>

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package com.mars.admin.domain.dashboard.controller;
 
+import com.mars.admin.domain.dashboard.dto.DailyUserStatsDto;
 import com.mars.admin.domain.dashboard.dto.DashboardResponseDto;
 import com.mars.admin.domain.dashboard.dto.MonthPostCountDto;
 import com.mars.admin.domain.dashboard.dto.MonthRegisterCountDto;
@@ -10,7 +11,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -25,8 +25,9 @@ public class DashboardController {
         Map<String, Long> totals = chartService.getTotals();
         List<MonthRegisterCountDto> monthlyRegisterData = chartService.getMonthlyRegisterCounts();
         List<MonthPostCountDto> monthPostCountData = chartService.getPostMonthCountTotals();
+        List<DailyUserStatsDto> dailyUserCountData = chartService.getDailyUserCounts();
         DashboardResponseDto dashboardResponseDto = DashboardResponseDto.of(totals, monthlyRegisterData,
-            monthPostCountData);
+            monthPostCountData, dailyUserCountData);
         return ResponseDto.of(dashboardResponseDto);
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DailyUserStatsDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DailyUserStatsDto.java
@@ -7,16 +7,18 @@ import lombok.Builder;
 @Builder
 public record DailyUserStatsDto(
     String date,
-    long users
+    long users,
+    long unregisteredUsers
 ) {
     private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("M/d");
-    private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("MM/dd");
+    private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public static DailyUserStatsDto of(String dateString, long users) {
+    public static DailyUserStatsDto of(String dateString, long users, long unregisteredUsers) {
         LocalDate date = LocalDate.parse(dateString, INPUT_FORMATTER);
         return DailyUserStatsDto.builder()
             .date(date.format(OUTPUT_FORMATTER))
             .users(users)
+            .unregisteredUsers(unregisteredUsers)
             .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DailyUserStatsDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DailyUserStatsDto.java
@@ -1,0 +1,22 @@
+package com.mars.admin.domain.dashboard.dto;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+
+@Builder
+public record DailyUserStatsDto(
+    String date,
+    long users
+) {
+    private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("M/d");
+    private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("MM/dd");
+
+    public static DailyUserStatsDto of(String dateString, long users) {
+        LocalDate date = LocalDate.parse(dateString, INPUT_FORMATTER);
+        return DailyUserStatsDto.builder()
+            .date(date.format(OUTPUT_FORMATTER))
+            .users(users)
+            .build();
+    }
+}

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/dto/DashboardResponseDto.java
@@ -8,17 +8,20 @@ import lombok.Builder;
 public record DashboardResponseDto(
     Map<String, Long> totals,
     List<MonthRegisterCountDto> monthlyRegisterData,
-    List<MonthPostCountDto> monthPostCountData
+    List<MonthPostCountDto> monthPostCountData,
+    List<DailyUserStatsDto> dailyUserStats
 ) {
     public static DashboardResponseDto of(
         Map<String, Long> totals,
         List<MonthRegisterCountDto> monthlyRegisterData,
-        List<MonthPostCountDto> monthPostCountData
+        List<MonthPostCountDto> monthPostCountData,
+        List<DailyUserStatsDto> dailyUserStats
     ) {
         return DashboardResponseDto.builder()
             .totals(totals)
             .monthlyRegisterData(monthlyRegisterData)
             .monthPostCountData(monthPostCountData)
+            .dailyUserStats(dailyUserStats)
             .build();
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -1,8 +1,10 @@
 package com.mars.admin.domain.dashboard.service;
 
 import com.mars.admin.domain.community.repository.CommunityRepository;
+import com.mars.admin.domain.dashboard.dto.DailyUserStatsDto;
 import com.mars.admin.domain.dashboard.dto.MonthPostCountDto;
 import com.mars.admin.domain.dashboard.dto.MonthRegisterCountDto;
+import com.mars.admin.domain.stats.repository.VisitLogRepository;
 import com.mars.admin.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -24,6 +26,7 @@ public class ChartService {
     
     private final UserRepository userRepository;
     private final CommunityRepository communityRepository;
+    private final VisitLogRepository visitLogRepository;
 
     public Map<String, Long> getTotals() {
         return Map.of(
@@ -100,5 +103,9 @@ public class ChartService {
         LocalDateTime end = now.atEndOfMonth().atTime(23, 59, 59);
 
         return userRepository.getMonthRegisterCount(start, end);
+    }
+
+    public List<DailyUserStatsDto> getDailyUserCounts() {
+        return visitLogRepository.getDailyUserStats();
     }
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/stats/repository/VisitLogRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/stats/repository/VisitLogRepository.java
@@ -1,10 +1,18 @@
 package com.mars.admin.domain.stats.repository;
 
+import com.mars.admin.domain.dashboard.dto.DailyUserStatsDto;
 import com.mars.common.model.stats.VisitLog;
+import java.util.List;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VisitLogRepository extends MongoRepository<VisitLog, String> {
-
+    @Aggregation(pipeline = {
+        "{ $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } }, users: { $addToSet: '$userId' } } }",
+        "{ $project: { _id: 0, date: '$_id', users: { $size: '$users' } } }",
+        "{ $sort: { date: 1 } }"
+    })
+    List<DailyUserStatsDto> getDailyUserStats();
 }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/stats/repository/VisitLogRepository.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/stats/repository/VisitLogRepository.java
@@ -9,9 +9,21 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VisitLogRepository extends MongoRepository<VisitLog, String> {
+
     @Aggregation(pipeline = {
-        "{ $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } }, users: { $addToSet: '$userId' } } }",
-        "{ $project: { _id: 0, date: '$_id', users: { $size: '$users' } } }",
+        "{ $group: { " +
+            "    _id: { " +
+            "        date: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } } " +
+            "    }, " +
+            "    loggedInUsers: { $addToSet: { $cond: [ { $ne: ['$userId', -1] }, '$userId', null ] } }, " +
+            "    guestIps: { $addToSet: { $cond: [ { $eq: ['$userId', -1] }, '$ip', null ] } } " +
+            "} }",
+        "{ $project: { " +
+            "    _id: 0, " +
+            "    date: '$_id.date', " +
+            "    users: { $ifNull: [ { $size: { $filter: { input: '$loggedInUsers', as: 'user', cond: { $ne: ['$$user', null] } } } }, 0 ] }, " +
+            "    unregisteredUsers: { $ifNull: [ { $size: { $filter: { input: '$guestIps', as: 'ip', cond: { $ne: ['$$ip', null] } } } }, 0 ] } " +
+            "} }",
         "{ $sort: { date: 1 } }"
     })
     List<DailyUserStatsDto> getDailyUserStats();


### PR DESCRIPTION
## 개요
### 어드민 페이지 일일 접속자 수 통계 구현 (BE, FE)
- 로그인/비로그인 사용자 구분하여 시각화
  - 로그인: userId, 비로그인: ip 기준으로 카운트
  <img width="540" alt="image" src="https://github.com/user-attachments/assets/7120dc35-e9b2-4424-9b3e-69ea704909a1" />

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).