### PR TITLE
[NPG-261] Admin - 감사 로그에서 이메일 클릭 시 User 페이지로 바로 전환

### DIFF
--- a/NangPaGo-admin/src/pages/Audit.jsx
+++ b/NangPaGo-admin/src/pages/Audit.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect} from 'react';
+import { useNavigate } from 'react-router-dom';
 import {getAuditLogs} from '../api/audit';
 
 export default function Audit() {
@@ -7,9 +8,14 @@ export default function Audit() {
   const [totalPages, setTotalPages] = useState(0);
   const [pageSize] = useState(10);
   const [expandedRow, setExpandedRow] = useState(null);
+  const navigate = useNavigate();
 
   const handleRowClick = (index) => {
     setExpandedRow(expandedRow === index ? null : index);
+  };
+
+  const handleEmailClick = (email) => {
+    navigate(`/dashboard/users?searchType=EMAIL&searchKeyword=${email}`);
   };
 
   const fetchData = async () => {
@@ -100,7 +106,12 @@ export default function Audit() {
                           </div>
                           <div>
                             <span className="font-semibold">Email: </span>
-                            <span>{log.email}</span>
+                            <button
+                              onClick={() => handleEmailClick(log.email)}
+                              className="text-blue-600 hover:underline"
+                            >
+                              {log.email}
+                            </button>
                           </div>
                           <div>
                             <span className="font-semibold">Request DTO: </span>

--- a/NangPaGo-admin/src/pages/Users.jsx
+++ b/NangPaGo-admin/src/pages/Users.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { getUserList, banUser, unBanUser } from '../api/usermanage';
 import { SOCIAL_BUTTON_STYLES } from '../common/styles/CommonButton.js';
 
@@ -11,7 +12,7 @@ export default function Users() {
   const [actionType, setActionType] = useState("");
   const [selectedStatuses, setSelectedStatuses] = useState([]);
   const [selectedProviders, setSelectedProviders] = useState([]);
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(0);
   const [sortField, setSortField] = useState('ID');
   const [isAscending, setIsAscending] = useState(true);
   const [dataUpdateFlag, setDataUpdateFlag] = useState(0);
@@ -20,6 +21,8 @@ export default function Users() {
   const [searchKeyword, setSearchKeyword] = useState('');
   const [appliedSearchType, setAppliedSearchType] = useState('');
   const [appliedSearchKeyword, setAppliedSearchKeyword] = useState('');
+
+  const location = useLocation();
 
   const userStatuses = [
     { value: 'ACTIVE', label: '정상' },
@@ -94,6 +97,13 @@ export default function Users() {
 
   const fetchData = async () => {
     try {
+      const params = new URLSearchParams(location.search);
+      const typeFromUrl = params.get('searchType');
+      const keywordFromUrl = params.get('searchKeyword');
+
+      if (typeFromUrl) setSearchType(typeFromUrl);
+      if (keywordFromUrl) setSearchKeyword(keywordFromUrl);
+
       const sortType = `${sortField}_${isAscending ? 'ASC' : 'DESC'}`;
       const response = await getUserList(
         currentPage,
@@ -101,8 +111,8 @@ export default function Users() {
         selectedStatuses,
         selectedProviders,
         pageSize,
-        appliedSearchType,
-        appliedSearchKeyword
+        typeFromUrl || appliedSearchType,
+        keywordFromUrl || appliedSearchKeyword
       );
       setUsers(response.data.data.content);
       setTotalPages(response.data.data.totalPages);
@@ -113,7 +123,7 @@ export default function Users() {
 
   useEffect(() => {
     fetchData();
-  }, [currentPage, isAscending, sortField, selectedStatuses, selectedProviders, dataUpdateFlag, appliedSearchType, appliedSearchKeyword]);
+  }, [currentPage, isAscending, sortField, selectedStatuses, selectedProviders, dataUpdateFlag, appliedSearchType, appliedSearchKeyword, location.search]);
 
   return (
     <div className="p-6">
@@ -267,7 +277,8 @@ export default function Users() {
                 <td className="px-4 py-2 text-sm text-gray-700 overflow-hidden whitespace-nowrap text-ellipsis">{user.updatedAt}</td>
                 <td className="px-4 py-2 text-sm text-gray-700 w-[120px]">
                   {user.userStatus === 'WITHDRAWN' ? (
-                    <div className="text-gray-500 px-2 py-1.5 w-[100px] overflow-hidden whitespace-nowrap text-ellipsis h-[32px] flex items-center border rounded">
+                    <div
+                      className="text-gray-500 px-2 py-1.5 w-[100px] overflow-hidden whitespace-nowrap text-ellipsis h-[32px] flex items-center border rounded">
                       WITHDRAWN
                     </div>
                   ) : (


### PR DESCRIPTION
## 개요
- Audit 페이지에서 row가 열려있는 상태에서 이메일(링크형식)을 클릭시
  <img width="50%" alt="image" src="https://github.com/user-attachments/assets/c0f396d1-c7ab-4cf7-8188-79c31e6aa155" />

- User 페이지로 이동 -> 해당 User가 이메일로 검색된 상태로 나타남
	- input 박스에 해당 이메일이 입력되어 검색 버튼이 눌린 상태(해당 사용자만 보임)
	<img width="50%" alt="image" src="https://github.com/user-attachments/assets/a26cda50-b2f3-4250-aba5-3640d2ff3380" />

## PR 유형

- [ ] 새로운 기능 추가

## PR Checklist

- [ ] PR 제목을 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).