### PR TITLE
[NPG-260] 감사로그 클릭 후 다른 페이지로 이동 시 열어놨던 행이 닫히게 수정

### DIFF
--- a/NangPaGo-admin/src/pages/Audit.jsx
+++ b/NangPaGo-admin/src/pages/Audit.jsx
@@ -18,9 +18,11 @@ export default function Audit() {
     navigate(`/dashboard/users?searchType=EMAIL&searchKeyword=${email}`);
   };
 
-  const fetchData = async () => {
+  const fetchData = async (newPage = currentPage) => {
     try {
-      const response = await getAuditLogs(currentPage, pageSize);
+      setExpandedRow(null);
+      setCurrentPage(newPage);
+      const response = await getAuditLogs(newPage, pageSize);
       setAuditLogs(response.data.data.content);
       setTotalPages(response.data.data.totalPages);
     } catch (error) {


### PR DESCRIPTION
## 개요
### Admin - Audit
- 수정 전: 감사 로그 클릭 후 다른 페이지 넘어가면, 열어놨던 행이 다른 페이지에서도 동일하게 열려있음
- 수정 한 부분: fetchData 함수 내부에서 `setExpandedRow(null);` 를 통해 상태를 초기화
- 수정 후: 감사 로그 클릭해서 행이 열려있어도 다른 페이지로 이동하면 행이 다시 닫혀있음

## PR 유형

- [x] 코드에 영향을 주지 않는 변경사항


## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).