### PR TITLE
[NPG-257] 버그: 사용자 활동 분석 차트 유저 레시피 카운트 안됨

### DIFF
--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/domain/dashboard/service/ChartService.java
@@ -149,16 +149,16 @@ public class ChartService {
     }
 
     private String getGroupedAction(String action) {
-        if (action.startsWith("USER")) {
-            return "회원 활동";
-        }
-        if (action.startsWith("RECIPE")) {
-            return "레시피";
-        }
         if (action.startsWith("USER_RECIPE")) {
             return "유저 레시피";
         }
-        if (action.startsWith("COMMUNITY")) {
+        else if (action.startsWith("USER")) {
+            return "회원 활동";
+        }
+        else if (action.startsWith("RECIPE")) {
+            return "레시피";
+        }
+        else if (action.startsWith("COMMUNITY")) {
             return "커뮤니티";
         }
         return action;


### PR DESCRIPTION
## 개요
### 버그 - 사용자 활동 분석 차트에서 `유저 레시피`가 정상적으로 카운트되지 않는 버그
- `USER_RECIPE`가 먼저 처리되도록 **`if-else` 문과 조건문 순서를 변경**하여 유저 레시피가 정상적으로 카운트됨

  <img width="360" alt="image" src="https://github.com/user-attachments/assets/00cb81e1-49c5-495e-b9bf-2a57cd0200d6" />


## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).