### PR TITLE
[NO-ISSUE] 레시피 Elasticsearch 인덱스 개발/운영 환경별로 분리

### DIFF
--- a/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/elasticsearch/ElasticsearchIndexConfig.java
+++ b/NangPaGo-api/NangPaGo-app/src/main/java/com/mars/app/config/elasticsearch/ElasticsearchIndexConfig.java
@@ -1,0 +1,15 @@
+package com.mars.app.config.elasticsearch;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ElasticsearchIndexConfig {
+
+    @Value("${spring.elasticsearch.index-name}")
+    private String indexName;
+
+    public String getIndexName() {
+        return indexName;
+    }
+}

--- a/NangPaGo-api/NangPaGo-app/src/main/resources/application.yml
+++ b/NangPaGo-api/NangPaGo-app/src/main/resources/application.yml
@@ -148,6 +148,9 @@ spring:
     activate:
       on-profile: local
 
+  elasticsearch:
+    index-name: recipe_dev
+
 logging:
   level:
     root: info
@@ -158,6 +161,9 @@ spring:
   config:
     activate:
       on-profile: prod
+
+  elasticsearch:
+    index-name: recipe_prod
 
 logging:
   file:
@@ -176,6 +182,8 @@ spring:
   config:
     activate:
       on-profile: test
+  elasticsearch:
+    index-name: recipe_dev
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/recipe/RecipeEs.java
+++ b/NangPaGo-api/NangPaGo-common/src/main/java/com/mars/common/model/recipe/RecipeEs.java
@@ -17,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Document(indexName = "recipes")
+@Document(indexName = "#{@elasticsearchIndexConfig.getIndexName()}")
 public class RecipeEs {
 
     @Id


### PR DESCRIPTION
## 개요
### ElasticSearch 인덱스 (개발/운영/테스트) 분리

- **기존 문제점**: ElasticSearch에서 `recipes`라는 하나의 인덱스를 사용하고 있었음

- **변경 사항**: `application.yml`을 통해 동적으로 인덱스를 설정하도록 변경
  - 개발 환경: `recipe_dev` 인덱스
  - 운영 환경: `recipe_prod` 인덱스  
  - 테스트 환경: `recipe_dev`와 동일한 인덱스 사용 (분리 여부 논의 필요)
### 전달사항

- **`recipe` 인덱스 생성 명령어**: Confluence의 `ElasticSearch recipe 인덱스 생성 명령어`에 정리되어 있음  (이미 인덱스가 생성되어 추가 작업은 필요 없음.)
  
- **ElasticSearch 관련 전달 사항**:
  - PR Merge 후, 기존의 `recipes` 인덱스를 삭제한 후,
  - `POST https://nangpago.site/api/recipe/bulk-upload/mysql`를 실행하면, 현재 운영 MySQL DB 기준으로 데이터가 업데이트될 것임


## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).