### PR TITLE
[NPG-276] Admin - CSRF 방어 기능 활성화

### DIFF
--- a/NangPaGo-admin/src/api/axiosInstance.js
+++ b/NangPaGo-admin/src/api/axiosInstance.js
@@ -11,19 +11,37 @@ export const setNavigate = (nav) => {
   navigate = nav;
 };
 
-axiosInstance.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    if (error.response && error.response.status === 401) {
-      if (navigate) {
-        const errorData = encodeURIComponent(JSON.stringify(error.response.data));
-        navigate(`/auth-error?error=${errorData}`);
-      } else {
-        window.location.href = '/auth-error';
+axiosInstance.interceptors.request.use(
+    (config) => {
+      const csrfCookie = document.cookie
+      .split('; ')
+      .find(row => row.startsWith('XSRF-TOKEN='));
+
+      if (csrfCookie) {
+        config.headers['X-XSRF-TOKEN'] = decodeURIComponent(
+            csrfCookie.split('=')[1]);
       }
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
-  }
+);
+
+axiosInstance.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      if (error.response && error.response.status === 401) {
+        if (navigate) {
+          const errorData = encodeURIComponent(
+              JSON.stringify(error.response.data));
+          navigate(`/auth-error?error=${errorData}`);
+        } else {
+          window.location.href = '/auth-error';
+        }
+      }
+      return Promise.reject(error);
+    }
 );
 
 export default axiosInstance;

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/handler/AdminSuccessHandler.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/auth/handler/AdminSuccessHandler.java
@@ -37,7 +37,7 @@ public class AdminSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String email = userDetails.getUsername();
 
         checkAuthority(email);
-        setCsrfToken(request, response);
+        issueCsrfTokenInCookie(request, response);
     }
 
     private void checkAuthority(String email) {
@@ -49,7 +49,7 @@ public class AdminSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         }
     }
 
-    private void setCsrfToken(HttpServletRequest request, HttpServletResponse response) {
+    private void issueCsrfTokenInCookie(HttpServletRequest request, HttpServletResponse response) {
         CsrfToken csrfToken = cookieCsrfTokenRepository.generateToken(request);
         cookieCsrfTokenRepository.saveToken(csrfToken, request, response);
     }

--- a/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/config/security/CsrfConfig.java
+++ b/NangPaGo-api/NangPaGo-admin/src/main/java/com/mars/admin/config/security/CsrfConfig.java
@@ -1,0 +1,21 @@
+package com.mars.admin.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+
+@Configuration
+public class CsrfConfig {
+
+    @Bean
+    public CsrfTokenRequestAttributeHandler csrfTokenRequestAttributeHandler() {
+        return new CsrfTokenRequestAttributeHandler();
+    }
+
+    @Bean
+    public CookieCsrfTokenRepository cookieCsrfTokenRepository() {
+        return CookieCsrfTokenRepository.withHttpOnlyFalse();
+    }
+
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- Admin 페이지는 `세션 인증`방식을 사용중이므로, CSRF 공격에 대한 취약점 발생. 
- Spring Security의 CSRF 방어 기능을 활성화 하여, GET 요청을 제외한 나머지 모든 요청은 헤더에 CSRF 토큰을 포함시키지 않으면 403을 반환하도록 보안 인증 레이어를 한 단계 추가한다.

## PR 유형

- [x] 코드 리팩토링

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).